### PR TITLE
Expose MCU serial number as a text sensor in ESPHome

### DIFF
--- a/esphome/components/fader_buddy/__init__.py
+++ b/esphome/components/fader_buddy/__init__.py
@@ -19,9 +19,13 @@ from esphome.const import CONF_ID, CONF_MODE
 
 MULTI_CONF = True
 DEPENDENCIES = ["i2c"]
+AUTO_LOAD = ["text_sensor"]
 
 fader_buddy_ns = cg.esphome_ns.namespace("fader_buddy")
 FaderBuddy = fader_buddy_ns.class_("FaderBuddy", cg.PollingComponent, i2c.I2CDevice)
+
+# Used by platform files (e.g. text_sensor) to reference the parent hub
+CONF_FADER_BUDDY_ID = "fader_buddy_id"
 
 # Define haptic mode enum (in global namespace, shared with firmware)
 HapticMode = cg.global_ns.enum("HapticMode")

--- a/esphome/components/fader_buddy/fader_buddy.cpp
+++ b/esphome/components/fader_buddy/fader_buddy.cpp
@@ -50,6 +50,9 @@ void FaderBuddy::setup() {
 
   ESP_LOGCONFIG(TAG, "FaderBuddy initialized (protocol v%d)", buffer);
 
+  // Read the chip serial number once (static factory ID) and publish it.
+  read_serial_number_();
+
   // Send initial haptic configurations to firmware
   for (uint8_t i = 0; i < 8; i++) {
     if (initial_haptic_configs_[i].valid) {
@@ -74,7 +77,35 @@ void FaderBuddy::dump_config() {
     ESP_LOGE(TAG, "Communication failed");
   }
 
+  if (!this->serial_number_.empty()) {
+    ESP_LOGCONFIG(TAG, "  Serial Number: %s", this->serial_number_.c_str());
+  }
+  LOG_TEXT_SENSOR("  ", "Serial Number", this->serial_text_sensor_);
+
   LOG_UPDATE_INTERVAL(this);
+}
+
+// Read the 10-byte chip serial number and cache it as an uppercase hex string.
+// The serial is a static factory ID, so this only needs to run once at setup.
+void FaderBuddy::read_serial_number_() {
+  uint8_t reg = REG_SERIAL;
+  uint8_t serial[10];
+  auto read_result = this->write_read(&reg, 1, serial, sizeof(serial));
+  if (read_result != esphome::i2c::ErrorCode::NO_ERROR) {
+    ESP_LOGW(TAG, "Failed to read serial number: %d", read_result);
+    return;
+  }
+
+  char buf[sizeof(serial) * 2 + 1];
+  for (size_t i = 0; i < sizeof(serial); i++) {
+    sprintf(buf + i * 2, "%02X", serial[i]);
+  }
+  this->serial_number_ = buf;
+  ESP_LOGCONFIG(TAG, "Serial number: %s", this->serial_number_.c_str());
+
+  if (this->serial_text_sensor_ != nullptr) {
+    this->serial_text_sensor_->publish_state(this->serial_number_);
+  }
 }
 
 float FaderBuddy::get_setup_priority() const { return setup_priority::DATA; }

--- a/esphome/components/fader_buddy/fader_buddy.h
+++ b/esphome/components/fader_buddy/fader_buddy.h
@@ -17,8 +17,11 @@
 
 #include "esphome/core/component.h"
 #include "esphome/components/i2c/i2c.h"
+#include "esphome/components/text_sensor/text_sensor.h"
 #include "esphome/core/automation.h"
 #include "esphome/core/optional.h"
+
+#include <string>
 
 namespace esphome {
 namespace fader_buddy {
@@ -54,6 +57,11 @@ class FaderBuddy : public PollingComponent, public i2c::I2CDevice {
     void set_invert(bool invert) { invert_ = invert; }
     void set_layer_value_change_min_interval(uint8_t layer, uint32_t min_interval_ms);
 
+    // Chip serial number (10-byte factory ID, read once at setup). Returns an
+    // uppercase hex string (e.g. "AABBCCDDEEFF00112233"), or "" if not yet read.
+    std::string get_serial_number() const { return serial_number_; }
+    void set_serial_text_sensor(text_sensor::TextSensor *s) { serial_text_sensor_ = s; }
+
     // Called only from codegen to store initial haptic configs
     void store_initial_layer_haptic_config(uint8_t layer, uint8_t mode, uint8_t detent_count, uint8_t detent_strength);
 
@@ -73,8 +81,12 @@ class FaderBuddy : public PollingComponent, public i2c::I2CDevice {
         Trigger<uint8_t> *on_double_tap_{new Trigger<uint8_t>()};
 
     private:
+        void read_serial_number_();
+
         // State variables
         uint32_t last_state_{0};
+        std::string serial_number_;
+        text_sensor::TextSensor *serial_text_sensor_{nullptr};
         HighFrequencyLoopRequester high_freq_;
         bool invert_{false};
         bool last_touch_{false};

--- a/esphome/components/fader_buddy/text_sensor.py
+++ b/esphome/components/fader_buddy/text_sensor.py
@@ -1,0 +1,39 @@
+# Copyright 2026 Scott Bezek
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import text_sensor
+
+from . import CONF_FADER_BUDDY_ID, FaderBuddy
+
+DEPENDENCIES = ["fader_buddy"]
+
+CONF_SERIAL_NUMBER = "serial_number"
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(CONF_FADER_BUDDY_ID): cv.use_id(FaderBuddy),
+        cv.Optional(CONF_SERIAL_NUMBER): text_sensor.text_sensor_schema(
+            entity_category="diagnostic",
+        ),
+    }
+)
+
+
+async def to_code(config):
+    parent = await cg.get_variable(config[CONF_FADER_BUDDY_ID])
+
+    if CONF_SERIAL_NUMBER in config:
+        sens = await text_sensor.new_text_sensor(config[CONF_SERIAL_NUMBER])
+        cg.add(parent.set_serial_text_sensor(sens))


### PR DESCRIPTION
Read the 10-byte REG_SERIAL factory ID once at setup and cache it as an uppercase hex string. Add a fader_buddy text_sensor platform with a serial_number key, expose get_serial_number() for lambdas, and log the serial in dump_config().