### PR TITLE
Rewrite motor control, add remote movement speed control

### DIFF
--- a/.github/workflows/i2c_protocol.yml
+++ b/.github/workflows/i2c_protocol.yml
@@ -1,0 +1,17 @@
+name: I2C Protocol Sync
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  check-i2c-data-sync:
+    name: Check i2c_data.h copies are in sync
+    runs-on: ubuntu-26.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Diff i2c_data.h copies against the canonical firmware copy
+        run: ./ci/util/check_i2c_data_sync.py

--- a/ABOUT_ESPHOME_INTEGRATION.md
+++ b/ABOUT_ESPHOME_INTEGRATION.md
@@ -208,11 +208,25 @@ Command the fader to move to a specific position.
     id: my_fader
     position: 128
     layer: 0  # Optional, defaults to layer 0
+
+# Example: move gently rather than at full speed
+- fader_buddy.remote_move_to:
+    id: my_fader
+    position: 200
+    move_time: 500ms
 ```
 
 **Position:** 0-255 (0 = bottom, 255 = top, unless inverted)
 
 **Layer:** Optional layer index (0-7). If the specified layer is not currently active, the position is stored and will be restored when that layer becomes active.
+
+**move_time:** Optional. How long a *full-scale* move (0 to 255) should take. Omit it, or use `0ms`, to move at full speed.
+
+This caps the fader's speed rather than scheduling the move, so a shorter move takes proportionally less time — with `move_time: 500ms`, a half-scale move takes about 250ms. Slowing moves down is mostly useful when several faders move at once, or when you want motion to read as deliberate rather than instant.
+
+Practical range is roughly **250ms to 700ms**, where actual timing lands within about 15% of the request. Longer values keep slowing the fader but increasingly under-run: the mechanism cannot move smoothly slower than about **1.1 seconds** for full travel, because below that speed the motor stops rotating continuously and creeps in small steps instead. Requests slower than that are clamped. Expect around 7% difference between moving up and moving down, since the fader's friction is not symmetric.
+
+Setting `move_time` on a layer that is not currently active also applies when that layer is restored later.
 
 ### fader_buddy.set_active_layer
 

--- a/ABOUT_ESPHOME_INTEGRATION.md
+++ b/ABOUT_ESPHOME_INTEGRATION.md
@@ -86,6 +86,7 @@ fader_buddy:
     layer_haptics:
       - layer: 0
         mode: smooth
+        default_speed: 120  # move deliberately rather than instantly
 
     # User moves fader → update light brightness
     on_manual_move:
@@ -130,6 +131,7 @@ For additional complete working examples, see the `esphome/examples/` directory:
     - `detents`: Creates distinct "notches" along the fader's travel (requires `detent_count`)
   - **detent_count** (optional, default: `0`): Number of detents (1-15, for detents mode only)
   - **detent_strength** (optional, default: `0`): Detent force feedback strength (0-7, for detents mode only)
+  - **default_speed** (optional, default: `255`): Move speed for this layer, 0-255, used by `fader_buddy.remote_move_to` and by lambda calls to `remote_move_to()` that don't pass a speed of their own. `255` is full speed; see the `speed` parameter of `fader_buddy.remote_move_to` below. This one is tracked in ESPHome rather than on the fader — the component looks up the active layer's value and sends it with each move — so changing it costs no extra I2C traffic.
   - **value_change_min_interval** (optional, default: `0ms`): Rate limiting for `on_manual_move` trigger on this layer. Useful to reduce traffic when controlling networked devices like zigbee lights. Set to `0ms` for no rate limiting. Keep as low as possible.
 
 ### Triggers
@@ -213,20 +215,22 @@ Command the fader to move to a specific position.
 - fader_buddy.remote_move_to:
     id: my_fader
     position: 200
-    move_time: 500ms
+    speed: 80
 ```
 
 **Position:** 0-255 (0 = bottom, 255 = top, unless inverted)
 
 **Layer:** Optional layer index (0-7). If the specified layer is not currently active, the position is stored and will be restored when that layer becomes active.
 
-**move_time:** Optional. How long a *full-scale* move (0 to 255) should take. Omit it, or use `0ms`, to move at full speed.
+**speed:** Optional. How fast to move, as a unitless **0-255** value: `255` is full speed, `0` is the slowest the fader moves smoothly. Omit it to use the layer's `default_speed`.
 
-This caps the fader's speed rather than scheduling the move, so a shorter move takes proportionally less time — with `move_time: 500ms`, a half-scale move takes about 250ms. Slowing moves down is mostly useful when several faders move at once, or when you want motion to read as deliberate rather than instant.
+The scale is linear in velocity, and both ends are usable — `0` is the slowest speed the mechanism sustains without creeping in stick-slip steps (roughly 700ms for full travel), and `255` removes the limit entirely. There is nothing outside the range worth reaching for.
 
-Practical range is roughly **250ms to 700ms**, where actual timing lands within about 15% of the request. Longer values keep slowing the fader but increasingly under-run: the mechanism cannot move smoothly slower than about **1.1 seconds** for full travel, because below that speed the motor stops rotating continuously and creeps in small steps instead. Requests slower than that are clamped. Expect around 7% difference between moving up and moving down, since the fader's friction is not symmetric.
+This caps the fader's speed rather than scheduling the move, so a shorter move takes proportionally less time — at a given speed, a half-scale move takes about half as long as a full-scale one. Slowing moves down is mostly useful when several faders move at once, or when you want motion to read as deliberate rather than instant.
 
-Setting `move_time` on a layer that is not currently active also applies when that layer is restored later.
+Treat it as a limit rather than a precise speed. It is realised through a friction-dependent mechanism, so actual velocity lands within about 15% of nominal, with around 7% difference between moving up and moving down.
+
+Moving a layer that is not currently active also stores the speed, so it applies when that layer is restored later.
 
 ### fader_buddy.set_active_layer
 

--- a/ABOUT_ESPHOME_INTEGRATION.md
+++ b/ABOUT_ESPHOME_INTEGRATION.md
@@ -131,7 +131,7 @@ For additional complete working examples, see the `esphome/examples/` directory:
     - `detents`: Creates distinct "notches" along the fader's travel (requires `detent_count`)
   - **detent_count** (optional, default: `0`): Number of detents (1-15, for detents mode only)
   - **detent_strength** (optional, default: `0`): Detent force feedback strength (0-7, for detents mode only)
-  - **default_speed** (optional, default: `255`): Move speed for this layer, 0-255, used by `fader_buddy.remote_move_to` and by lambda calls to `remote_move_to()` that don't pass a speed of their own. `255` is full speed; see the `speed` parameter of `fader_buddy.remote_move_to` below. This one is tracked in ESPHome rather than on the fader — the component looks up the active layer's value and sends it with each move — so changing it costs no extra I2C traffic.
+  - **default_speed** (optional, default: `255`, requires fader firmware 1.1+): Move speed for this layer, 0-255, used by `fader_buddy.remote_move_to` and by lambda calls to `remote_move_to()` that don't pass a speed of their own. `255` is full speed; see the `speed` parameter of `fader_buddy.remote_move_to` below. This one is tracked in ESPHome rather than on the fader — the component looks up the active layer's value and sends it with each move — so changing it costs no extra I2C traffic.
   - **value_change_min_interval** (optional, default: `0ms`): Rate limiting for `on_manual_move` trigger on this layer. Useful to reduce traffic when controlling networked devices like zigbee lights. Set to `0ms` for no rate limiting. Keep as low as possible.
 
 ### Triggers
@@ -223,6 +223,8 @@ Command the fader to move to a specific position.
 **Layer:** Optional layer index (0-7). If the specified layer is not currently active, the position is stored and will be restored when that layer becomes active.
 
 **speed:** Optional. How fast to move, as a unitless **0-255** value: `255` is full speed, `0` is the slowest the fader moves smoothly. Omit it to use the layer's `default_speed`.
+
+Requires fader firmware **1.1 or newer**. On older firmware the component logs a warning once and moves at full speed instead; it checks the firmware version at startup, so a `default_speed` that cannot be honoured is reported then rather than on the first move.
 
 The scale is linear in velocity, and both ends are usable — `0` is the slowest speed the mechanism sustains without creeping in stick-slip steps (roughly 700ms for full travel), and `255` removes the limit entirely. There is nothing outside the range worth reaching for.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,87 @@
+# Changelog
+
+FaderBuddy has three pieces that version independently: the **hardware**, the
+**fader firmware** (ATtiny1616), and the **ESPHome component** that drives it
+from a host. They are deliberately decoupled - a fader in the field can be
+running older firmware than the host talking to it - so this file records what
+each release changed and which combinations work together.
+
+Separately, the **I2C protocol version** (reported at `REG_VERSION`) describes
+the wire format of the register map. It is bumped only when the layout of an
+existing register changes, never for additive features that an older host can
+simply not use. Hosts should feature-detect on the firmware version rather than
+the protocol version; see `firmware/src/shared/i2c_data.h`.
+
+## Compatibility
+
+| Hardware | Firmware | I2C protocol | ESPHome component | Notes |
+|---|---|---|---|---|
+| Rev A | 1.1 | 5 | 0.2.0 | Current |
+| Rev A | 1.1 | 5 | 0.1.0 | Works; host cannot use move speed |
+| Rev A | 1.0 | 5 | 0.2.0 | Works; move speed logs a warning and falls back to full speed |
+| Rev A | 1.0 | 5 | 0.1.0 | Works |
+
+Firmware 1.0 does not report a version at all (`REG_FW_VERSION` did not exist),
+so a host reads `0xFFFF` and treats the fader as 1.0.
+
+Component 0.1.0 requires the fader's protocol version to match exactly, so it
+will refuse to start against any future firmware that bumps the protocol.
+0.2.0 accepts equal-or-newer and warns instead - meaning a protocol bump is
+only safe once hosts have moved to 0.2.0 or later.
+
+---
+
+## Hardware
+
+### Rev A
+
+All boards built to date. These are silkscreened with the build commit hash and
+date rather than a revision number; "Rev A" is a label for the changelog, not
+something printed on the board.
+
+---
+
+## Firmware (ATtiny1616)
+
+### 1.1 - unreleased
+
+- Rewritten remote-movement control: PD on position with a per-direction
+  friction feedforward, a stiction ramp, and a backlash take-up ramp. Moves are
+  quieter and no longer overshoot. See `firmware/ABOUT_MOTOR_CONTROL.md`.
+- `LAYER_TARGET` (0x0E) accepts an optional 4th byte setting move speed, as a
+  unitless 0-255 value across the validated speed range (255 = full speed).
+  Three-byte writes are unchanged, so this is backwards compatible.
+- New `REG_FW_VERSION` (0x11), reporting a packed `(major << 8) | minor`.
+  This is the first firmware that reports a version.
+- Debug-only registers moved from 0x10-0x12 to 0xF0-0xF2, so production
+  registers can keep growing from 0x10. They remain compiled out of production
+  builds.
+- On a movement timeout, a fader that is essentially in position now goes idle
+  quietly instead of latching `MODE_ERROR` and needing a host round trip.
+
+### 1.0
+
+The last unversioned firmware - everything released before `REG_FW_VERSION`
+existed. Protocol v5: firmware-managed layers, 16-bit haptic config, and the
+layer-addressed registers.
+
+---
+
+## ESPHome component
+
+### 0.2.0 - unreleased
+
+- `fader_buddy.remote_move_to` takes `speed:` (0-255), and `layer_haptics`
+  takes `default_speed:` for moves that don't name one. The default is tracked
+  host-side and sent with each move rather than stored on the fader.
+- Reads and logs the fader's firmware version at startup, and warns rather
+  than silently doing nothing when a config asks for a move speed the fader's
+  firmware cannot honour (the move runs at full speed instead).
+- Accepts a fader reporting a newer protocol version, warning instead of
+  failing to start. Only an older protocol is still treated as incompatible.
+
+### 0.1.0
+
+The last unversioned component - everything before this file existed. Layer
+management, haptic config, rate-limited triggers, the serial number text
+sensor, and position/touch/double-tap handling.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,18 @@ layer-addressed registers.
 
 ### 0.3.0 - unreleased
 
+- The hub now creates its own diagnostic text sensors - serial number and
+  firmware version - so a bare `fader_buddy:` block reports what it is with no
+  entity yaml at all. Names default to `<hub id> Serial Number` / `<hub id>
+  Firmware Version`; override `name:`, or set `internal: true` /
+  `disabled_by_default: true`, on the hub's `serial_number:` /
+  `firmware_version:` key. Firmware version had no sensor before, only a log
+  line.
+- **Deprecated:** `text_sensor: platform: fader_buddy`, to be removed in 0.5.0.
+  It still works and still wins over the hub's own serial number sensor, so
+  there are never two, but it now logs a deprecation warning. To migrate,
+  delete the `text_sensor:` block and move any `name:`/`icon:` onto the hub's
+  `serial_number:` key.
 - Fixed `remote_move_to` at speed 255 re-using the previous speed limit. Full
   speed was sent as a 3-byte write, which leaves the layer's stored speed
   alone, so a move after any slower one silently kept the old limit. The speed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,21 @@ for production purposes.
   diagnostic.
 - Calibration EEPROM format changed - the first boot after updating falls
   back to default endpoints until self-calibration is re-run.
+- Self-calibration now returns the fader to the active layer's position using
+  the newly measured endpoints. It previously re-used a target derived from the
+  bounds it had just replaced, so the fader settled slightly off.
+- The position nonce in `STATE` is now actually incremented on local input. It
+  had no producer, so a user move that ended on the same 8-bit position as it
+  started was invisible to the host.
+- The backlash take-up ceiling is re-armed on a direction reversal rather than
+  on every `LAYER_TARGET` write. A host streaming position updates previously
+  held the fader at the take-up duty - roughly half speed - for the whole
+  gesture.
+- Detent haptics no longer pull toward the top of travel when the fader is
+  below the calibrated minimum (reachable with a stale calibration).
+- Fixed the hysteresis window being half-width when a move ended at the very top
+  of travel, which made a fader parked there twice as likely to report spurious
+  user input.
 
 ### 1.1 - unreleased
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,10 @@ the protocol version; see `firmware/src/shared/i2c_data.h`.
 
 | Hardware | Firmware | I2C protocol | ESPHome component | Notes |
 |---|---|---|---|---|
-| Rev A | 1.1 | 5 | 0.2.0 | Current |
+| Rev A | 1.2 | 5 | 0.3.0 | Current |
+| Rev A | 1.2 | 5 | 0.2.0 | Works; host does not log the motor characterisation |
+| Rev A | 1.1 | 5 | 0.3.0 | Works; no motor characterisation to report |
+| Rev A | 1.1 | 5 | 0.2.0 | Works |
 | Rev A | 1.1 | 5 | 0.1.0 | Works; host cannot use move speed |
 | Rev A | 1.0 | 5 | 0.2.0 | Works; move speed logs a warning and falls back to full speed |
 | Rev A | 1.0 | 5 | 0.1.0 | Works |
@@ -43,6 +46,50 @@ something printed on the board.
 
 ## Firmware (ATtiny1616)
 
+### 1.2 - unreleased
+
+- Remote movement restructured as explicit cascade control: the position loop
+  sets a velocity reference and an inner velocity loop realises it. The old
+  flat `KP*e - KD*v + FF` was algebraically the same loop, but writing it out
+  exposed two defects it was hiding.
+- The feedforward is now the plant model inverted, `breakaway + v_ref/k`,
+  instead of a fixed duty. A fixed feedforward commands a fixed speed, so no
+  slower speed was reachable without subtracting drive back off - which is what
+  the one-sided velocity governor did, and why slow moves limit-cycled
+  (overshoot, brake, fall under, accelerate). The governor and its companion
+  error clamp are both gone; the speed limit is now a clamp on the reference.
+- The velocity loop gain is scaled by `1/k`. Its open-loop gain is `k*KV`, so a
+  higher-torque motor previously closed a proportionally hotter loop and rang
+  through the lag of the velocity estimate - visible as the movement chugging
+  even at full speed, on a fader with more torque than the reference unit.
+- The stall-escape ramp is shed over ~20 ms rather than dropped in one tick,
+  which was a relay that chattered around the stall threshold.
+- The on-target window is sized from the time it takes to actually stop
+  (reaction + detection + coast, 15 ms) rather than from the coast alone
+  (6 ms), and is clamped to 8-20 ADC counts. The old figure produced a window a
+  low-friction fader could not land inside, so it dithered at the end of a move
+  instead of settling. The default window goes from 6 to 8 ADC counts.
+
+- Self-calibration now characterises the motor as well as the endpoints,
+  measuring per-direction breakaway duty, the speed/duty slope above it, and
+  the speed motion starts at, then deriving the friction feedforward, the
+  take-up ceiling and the on-target deadband from them. This is what makes the
+  tuning hold across faders whose friction or torque differs from the unit the
+  constants were centred on; a fader with materially lower stiction previously
+  hunted at the deadband and could not settle. See
+  `firmware/ABOUT_MOTOR_CONTROL.md`.
+- New `REG_MOTOR_CAL` (0x12), reporting those measurements and the gains
+  derived from them. Read-only and diagnostic; a host that ignores it loses
+  nothing.
+- Calibration is stored in one EEPROM record together with the endpoints. The
+  record's magic changed, so the first boot after this update falls back to
+  default endpoints until self-calibration is run - which it needs to be
+  anyway, to measure the motor.
+- Unrelated but necessary to fit the above: dropped an unused
+  `<megaTinyCore.h>` include that was pulling the whole serial stack into a
+  build with serial disabled, and moved several hot paths off floating point.
+  Net flash is now below the pre-1.1 firmware despite the added feature.
+
 ### 1.1 - unreleased
 
 - Rewritten remote-movement control: PD on position with a per-direction
@@ -68,6 +115,14 @@ layer-addressed registers.
 ---
 
 ## ESPHome component
+
+### 0.3.0 - unreleased
+
+- Reads `REG_MOTOR_CAL` at startup and logs what the fader measured about its
+  motor, plus the gains derived from it, or a note that the unit has not been
+  characterised yet. Diagnostic only - nothing else in the component depends
+  on it - but it is the only way to see those numbers on a bench with no test
+  jig attached.
 
 ### 0.2.0 - unreleased
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,33 +14,33 @@ the protocol version; see `firmware/src/shared/i2c_data.h`.
 
 ## Compatibility
 
-| Hardware | Firmware | I2C protocol | ESPHome component | Notes |
-|---|---|---|---|---|
-| Rev A | 1.2 | 5 | 0.3.0 | Current |
-| Rev A | 1.2 | 5 | 0.2.0 | Works; host does not log the motor characterisation |
-| Rev A | 1.1 | 5 | 0.3.0 | Works; no motor characterisation to report |
-| Rev A | 1.1 | 5 | 0.2.0 | Works |
-| Rev A | 1.1 | 5 | 0.1.0 | Works; host cannot use move speed |
-| Rev A | 1.0 | 5 | 0.2.0 | Works; move speed logs a warning and falls back to full speed |
-| Rev A | 1.0 | 5 | 0.1.0 | Works |
+Any firmware works with any component 0.2.0 or later - a component newer than
+the firmware just logs a warning and skips features the firmware can't do
+(e.g. move speed, motor characterisation). Component 0.1.0 needs the fader's
+protocol version to match exactly, so it won't start against a future
+firmware that bumps the protocol.
 
-Firmware 1.0 does not report a version at all (`REG_FW_VERSION` did not exist),
-so a host reads `0xFFFF` and treats the fader as 1.0.
-
-Component 0.1.0 requires the fader's protocol version to match exactly, so it
-will refuse to start against any future firmware that bumps the protocol.
-0.2.0 accepts equal-or-newer and warns instead - meaning a protocol bump is
-only safe once hosts have moved to 0.2.0 or later.
+Firmware 1.0 predates `REG_FW_VERSION` and reports no version at all; hosts
+that check it will read `0xFFFF` and should treat that as firmware 1.0.
 
 ---
 
 ## Hardware
 
-### Rev A
+### v1
 
-All boards built to date. These are silkscreened with the build commit hash and
-date rather than a revision number; "Rev A" is a label for the changelog, not
-something printed on the board.
+All boards built to date - all are essentially identical, with minor changes
+for production purposes.
+
+- **v1.3.1** (pre-release) - adds a panelized gerber/BOM/CPL export for
+  ordering 10 boards per panel. Only board change is two vias moved 0.75mm
+  for mousebite clearance.
+- **v1.3** - design files migrated to KiCad 10 (from 8); back silkscreen
+  updated to say "FaderBuddy" instead of "motor fader".
+- **v1.2** - fixed the JLCPCB BOM part number for the microcontroller, which
+  had pointed at the ATtiny816 (1 ADC) instead of the ATtiny1616 (2 ADCs) this
+  design needs.
+- **v1.1 and earlier** (v0.1-v1.0) - initial bring-up; error in JLC part numbers.
 
 ---
 
@@ -48,63 +48,33 @@ something printed on the board.
 
 ### 1.2 - unreleased
 
-- Remote movement restructured as explicit cascade control: the position loop
-  sets a velocity reference and an inner velocity loop realises it. The old
-  flat `KP*e - KD*v + FF` was algebraically the same loop, but writing it out
-  exposed two defects it was hiding.
-- The feedforward is now the plant model inverted, `breakaway + v_ref/k`,
-  instead of a fixed duty. A fixed feedforward commands a fixed speed, so no
-  slower speed was reachable without subtracting drive back off - which is what
-  the one-sided velocity governor did, and why slow moves limit-cycled
-  (overshoot, brake, fall under, accelerate). The governor and its companion
-  error clamp are both gone; the speed limit is now a clamp on the reference.
-- The velocity loop gain is scaled by `1/k`. Its open-loop gain is `k*KV`, so a
-  higher-torque motor previously closed a proportionally hotter loop and rang
-  through the lag of the velocity estimate - visible as the movement chugging
-  even at full speed, on a fader with more torque than the reference unit.
-- The stall-escape ramp is shed over ~20 ms rather than dropped in one tick,
-  which was a relay that chattered around the stall threshold.
-- The on-target window is sized from the time it takes to actually stop
-  (reaction + detection + coast, 15 ms) rather than from the coast alone
-  (6 ms), and is clamped to 8-20 ADC counts. The old figure produced a window a
-  low-friction fader could not land inside, so it dithered at the end of a move
-  instead of settling. The default window goes from 6 to 8 ADC counts.
-
-- Self-calibration now characterises the motor as well as the endpoints,
-  measuring per-direction breakaway duty, the speed/duty slope above it, and
-  the speed motion starts at, then deriving the friction feedforward, the
-  take-up ceiling and the on-target deadband from them. This is what makes the
-  tuning hold across faders whose friction or torque differs from the unit the
-  constants were centred on; a fader with materially lower stiction previously
-  hunted at the deadband and could not settle. See
-  `firmware/ABOUT_MOTOR_CONTROL.md`.
-- New `REG_MOTOR_CAL` (0x12), reporting those measurements and the gains
-  derived from them. Read-only and diagnostic; a host that ignores it loses
-  nothing.
-- Calibration is stored in one EEPROM record together with the endpoints. The
-  record's magic changed, so the first boot after this update falls back to
-  default endpoints until self-calibration is run - which it needs to be
-  anyway, to measure the motor.
-- Unrelated but necessary to fit the above: dropped an unused
-  `<megaTinyCore.h>` include that was pulling the whole serial stack into a
-  build with serial disabled, and moved several hot paths off floating point.
-  Net flash is now below the pre-1.1 firmware despite the added feature.
+- Remote movement now uses cascade control (position loop sets a velocity
+  reference, an inner loop realises it) with a friction feedforward derived
+  from the plant model rather than a fixed duty. See
+  `firmware/ABOUT_MOTOR_CONTROL.md` for why.
+- Self-calibration now also characterises the motor (per-direction breakaway
+  duty, speed/duty slope) and derives the feedforward, take-up ceiling, and
+  on-target deadband from it, so tuning holds across faders with different
+  friction or torque.
+- New `REG_MOTOR_CAL` (0x12), reporting those measurements. Read-only and
+  diagnostic.
+- Calibration EEPROM format changed - the first boot after updating falls
+  back to default endpoints until self-calibration is re-run.
 
 ### 1.1 - unreleased
 
 - Rewritten remote-movement control: PD on position with a per-direction
   friction feedforward, a stiction ramp, and a backlash take-up ramp. Moves are
   quieter and no longer overshoot. See `firmware/ABOUT_MOTOR_CONTROL.md`.
-- `LAYER_TARGET` (0x0E) accepts an optional 4th byte setting move speed, as a
-  unitless 0-255 value across the validated speed range (255 = full speed).
-  Three-byte writes are unchanged, so this is backwards compatible.
+- `LAYER_TARGET` (0x0E) accepts an optional 4th byte setting move speed
+  (0-255, 255 = full speed). Three-byte writes are unchanged, so this is
+  backwards compatible.
 - New `REG_FW_VERSION` (0x11), reporting a packed `(major << 8) | minor`.
   This is the first firmware that reports a version.
 - Debug-only registers moved from 0x10-0x12 to 0xF0-0xF2, so production
-  registers can keep growing from 0x10. They remain compiled out of production
-  builds.
+  registers can keep growing from 0x10.
 - On a movement timeout, a fader that is essentially in position now goes idle
-  quietly instead of latching `MODE_ERROR` and needing a host round trip.
+  quietly instead of latching `MODE_ERROR`.
 
 ### 1.0
 
@@ -119,19 +89,15 @@ layer-addressed registers.
 ### 0.3.0 - unreleased
 
 - Reads `REG_MOTOR_CAL` at startup and logs what the fader measured about its
-  motor, plus the gains derived from it, or a note that the unit has not been
-  characterised yet. Diagnostic only - nothing else in the component depends
-  on it - but it is the only way to see those numbers on a bench with no test
-  jig attached.
+  motor, or a note that it hasn't been characterised yet. Diagnostic only.
 
 ### 0.2.0 - unreleased
 
 - `fader_buddy.remote_move_to` takes `speed:` (0-255), and `layer_haptics`
-  takes `default_speed:` for moves that don't name one. The default is tracked
-  host-side and sent with each move rather than stored on the fader.
-- Reads and logs the fader's firmware version at startup, and warns rather
-  than silently doing nothing when a config asks for a move speed the fader's
-  firmware cannot honour (the move runs at full speed instead).
+  takes `default_speed:` for moves that don't name one.
+- Reads and logs the fader's firmware version at startup, and warns instead
+  of silently doing nothing when a config asks for a move speed the fader's
+  firmware can't honour (the move runs at full speed instead).
 - Accepts a fader reporting a newer protocol version, warning instead of
   failing to start. Only an older protocol is still treated as incompatible.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,11 @@ layer-addressed registers.
 
 - Reads `REG_MOTOR_CAL` at startup and logs what the fader measured about its
   motor, or a note that it hasn't been characterised yet. Diagnostic only.
+- Reports the fader's mode changes, which previously went unlogged entirely:
+  self-calibration starting and finishing (re-reading `REG_MOTOR_CAL` on
+  completion, so the run's own measurements are logged rather than the ones
+  read at startup), and a warning whenever the fader latches `MODE_ERROR` -
+  including a failed endpoint sweep, which was silent.
 
 ### 0.2.0 - unreleased
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,12 @@ layer-addressed registers.
   `disabled_by_default: true`, on the hub's `serial_number:` /
   `firmware_version:` key. Firmware version had no sensor before, only a log
   line.
+- The hub also creates a **Self Calibration** button, so a fader can be
+  recalibrated from Home Assistant without writing an automation around the
+  `fader_buddy.run_self_calibration` action. `entity_category: config`, since
+  pressing it drives the carriage to both ends for several seconds - HA files
+  it with the device's settings rather than its controls. Rename it with
+  `self_calibration: {name: ...}`, or hide it with `internal: true`.
 - **Deprecated:** `text_sensor: platform: fader_buddy`, to be removed in 0.5.0.
   It still works and still wins over the hub's own serial number sensor, so
   there are never two, but it now logs a deprecation warning. To migrate,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,10 @@ layer-addressed registers.
 
 ### 0.3.0 - unreleased
 
+- Fixed `remote_move_to` at speed 255 re-using the previous speed limit. Full
+  speed was sent as a 3-byte write, which leaves the layer's stored speed
+  alone, so a move after any slower one silently kept the old limit. The speed
+  byte is now sent on every move when the firmware supports it.
 - Reads `REG_MOTOR_CAL` at startup and logs what the fader measured about its
   motor, or a note that it hasn't been characterised yet. Diagnostic only.
 - Reports the fader's mode changes, which previously went unlogged entirely:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,9 @@ FaderBuddy is a bidirectional motor fader control system with integrated capacit
 - **firmware/** - ATtiny1616 firmware (PlatformIO project, Arduino framework)
   - `src/main.cpp` - Main firmware logic with motor control loop and I2C peripheral
   - `src/shared/i2c_data.h` - I2C protocol v5 definitions (shared across all components)
+  - `ABOUT_MOTOR_CONTROL.md` - **Read before touching the movement code.** Measured plant
+    model, why the control law is shaped as it is, and how the gains are centred for
+    hardware variance rather than tuned against one fader
 - **esphome/** - ESPHome custom component for Home Assistant integration
   - `components/fader_buddy/` - Core component for interfacing with FaderBuddy boards
   - `examples/multi-fader-display.yaml` - ESP32-S3 example with LVGL display
@@ -45,7 +48,15 @@ pio run --target monitor
 
 # Clean build
 pio run --target clean
+
+# System-identification build, adding the debug registers used to measure the
+# motor. Not for production - it lets a host drive the H-bridge directly.
+pio run -e fader_buddy_lab --target upload
 ```
+
+For measuring control-loop behaviour on the test jig, `production_tools/programAndTest`
+has an `env:lab` firmware providing a serial-driven measurement harness (step-response
+capture and runtime gain tuning). See `firmware/ABOUT_MOTOR_CONTROL.md`.
 
 The firmware uses UPDI programming via a USB-to-serial adapter. Upload port and monitor port can be configured in `platformio.ini`.
 
@@ -164,8 +175,17 @@ The FaderBuddy acts as an I2C peripheral with a configurable address (base 0x20 
 - **8 layers per fader**: Each with independent target position and haptic configuration
 - **State register** (0x01): 32-bit packed register containing mode, layer, nonces, and touch state
 - **Position/haptic nonces**: Used to detect user input vs. remote command echo
+- **Optional move time**: `LAYER_TARGET` (0x0E) accepts an optional 4th byte capping move
+  speed (full-scale travel time in 10ms units, 0 = unlimited). Three-byte writes behave
+  exactly as before, so this is backwards compatible and did not bump the protocol version
+- **Debug registers** (0x10-0x12): open-loop drive, control-loop internals, and runtime gain
+  overrides. Compiled out unless `DEBUG_DRIVE` is defined, so they are absent from
+  production builds
 
 Refer to `i2c_data.h` for complete register map and bit field definitions.
+
+When adding to the protocol, prefer optional trailing bytes over new register semantics -
+that keeps older controllers working and avoids a version bump.
 
 ### State Machine
 
@@ -173,10 +193,13 @@ The firmware implements a state machine to arbitrate between remote control and 
 
 1. **MODE_REMOTE_MOVEMENT_IN_PROGRESS** (0)
    - Motor actively moving to commanded target position
-   - Haptics disabled, simple PID movement
+   - Haptics disabled; PD control plus a friction feedforward, with a stall-escape
+     ramp and a backlash take-up ceiling (see `firmware/ABOUT_MOTOR_CONTROL.md`)
    - Transitions to INPUT_ACTIVE if touch detected for >50ms
    - Transitions to INPUT_IDLE when target reached and stable for >300ms
-   - Transitions to ERROR if movement timeout (8 seconds)
+   - Transitions to ERROR if movement timeout (8 seconds) AND the remaining error is
+     large; a small error at timeout means the fader arrived but kept dithering, so
+     it goes quietly idle instead of latching an error the host must clear
 
 2. **MODE_INPUT_ACTIVE** (1)
    - User is touching/moving the fader

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,6 +134,9 @@ esphome run examples/multi-fader-display.yaml
 ```
 
 **Key Features:**
+- Self-creating diagnostic text sensors (serial number, firmware version) - the hub
+  declares them itself, so no `text_sensor:` platform block is needed. The old
+  `text_sensor: platform: fader_buddy` form is deprecated and goes away in 0.5.0
 - Layer-aware automation triggers: `manual_move`, `touch_change`, `double_tap`
 - Per-layer haptic configuration (detent count, strength, mode)
 - Per-layer position restore on layer changes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,9 +134,10 @@ esphome run examples/multi-fader-display.yaml
 ```
 
 **Key Features:**
-- Self-creating diagnostic text sensors (serial number, firmware version) - the hub
-  declares them itself, so no `text_sensor:` platform block is needed. The old
-  `text_sensor: platform: fader_buddy` form is deprecated and goes away in 0.5.0
+- Self-creating entities - the hub declares them itself, so no platform blocks are
+  needed: diagnostic text sensors (serial number, firmware version) and a config
+  button (self calibration). The old `text_sensor: platform: fader_buddy` form is
+  deprecated and goes away in 0.5.0
 - Layer-aware automation triggers: `manual_move`, `touch_change`, `double_tap`
 - Per-layer haptic configuration (detent count, strength, mode)
 - Per-layer position restore on layer changes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,8 +192,10 @@ The FaderBuddy acts as an I2C peripheral with a configurable address (base 0x20 
 - **Optional move speed**: `LAYER_TARGET` (0x0E) accepts an optional 4th byte capping move
   speed, as a unitless 0-255 value spanning the validated speed range (255 = full speed).
   Three-byte writes behave exactly as before, so this is backwards compatible and did not
-  bump the protocol version; send full-speed moves as 3-byte writes, since firmware
-  predating the byte ignores a 4-byte write entirely
+  bump the protocol version. A host that uses the byte should send it on every move,
+  255 included - a 3-byte write leaves the layer's *stored* speed in place rather than
+  moving at full speed. Send 3 bytes only to firmware predating the byte, which ignores
+  a 4-byte write entirely
 - **Firmware version** (0x11): `REG_FW_VERSION`, a packed `(major << 8) | minor` u16, distinct
   from the protocol version at 0x00. Hosts feature-detect on this; firmware predating it reads
   back as 0xFFFF. The protocol version is only bumped when an existing register's wire format

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,13 @@ FaderBuddy is a bidirectional motor fader control system with integrated capacit
 
 - **electronics/** - KiCad PCB design files (schematic and board layout)
 - **firmware/** - ATtiny1616 firmware (PlatformIO project, Arduino framework)
-  - `src/main.cpp` - Main firmware logic with motor control loop and I2C peripheral
+  - `src/main.cpp` - Mode state machine, control law, haptics, touch, I2C peripheral
+  - `src/motor_control.h` - Motor drive primitives and the MOVE_* tuning constants,
+    shared between the control law and the characterisation. main.cpp owns every
+    definition declared here
+  - `src/motor_cal.{h,cpp}` - Self-calibration: the endpoint sweep and the per-unit
+    motor characterisation, plus the derivation of the live gains from it. Driven a
+    tick at a time by `motorcal_tick()`; the caller owns the mode and the EEPROM
   - `src/shared/i2c_data.h` - I2C protocol v5 definitions (shared across all components)
   - `ABOUT_MOTOR_CONTROL.md` - **Read before touching the movement code.** Measured plant
     model, why the control law is shaped as it is, and how the gains are centred for
@@ -192,6 +198,11 @@ The FaderBuddy acts as an I2C peripheral with a configurable address (base 0x20 
   from the protocol version at 0x00. Hosts feature-detect on this; firmware predating it reads
   back as 0xFFFF. The protocol version is only bumped when an existing register's wire format
   changes, never for additive features. 0x10 is reserved for the I2C bootloader work
+- **Motor characterisation** (0x12): `REG_MOTOR_CAL`, 12 read-only bytes reporting what
+  self-calibration measured about this unit's motor (per-direction breakaway duty, speed/duty
+  slope, Stribeck jump) plus the derived velocity floor and deadband the control law is
+  actually running. Present in production builds, so a unit can be diagnosed with nothing but
+  an I2C host attached
 - **Debug registers** (0xF0-0xF2): open-loop drive, control-loop internals, and runtime gain
   overrides. Compiled out unless `DEBUG_DRIVE` is defined, so they are absent from
   production builds. They sit at the top of the address space deliberately, so new

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,12 +175,15 @@ The FaderBuddy acts as an I2C peripheral with a configurable address (base 0x20 
 - **8 layers per fader**: Each with independent target position and haptic configuration
 - **State register** (0x01): 32-bit packed register containing mode, layer, nonces, and touch state
 - **Position/haptic nonces**: Used to detect user input vs. remote command echo
-- **Optional move time**: `LAYER_TARGET` (0x0E) accepts an optional 4th byte capping move
-  speed (full-scale travel time in 10ms units, 0 = unlimited). Three-byte writes behave
-  exactly as before, so this is backwards compatible and did not bump the protocol version
-- **Debug registers** (0x10-0x12): open-loop drive, control-loop internals, and runtime gain
+- **Optional move speed**: `LAYER_TARGET` (0x0E) accepts an optional 4th byte capping move
+  speed, as a unitless 0-255 value spanning the validated speed range (255 = full speed).
+  Three-byte writes behave exactly as before, so this is backwards compatible and did not
+  bump the protocol version; send full-speed moves as 3-byte writes, since firmware
+  predating the byte ignores a 4-byte write entirely
+- **Debug registers** (0xF0-0xF2): open-loop drive, control-loop internals, and runtime gain
   overrides. Compiled out unless `DEBUG_DRIVE` is defined, so they are absent from
-  production builds
+  production builds. They sit at the top of the address space deliberately, so new
+  production registers can keep growing from 0x10 without a hole
 
 Refer to `i2c_data.h` for complete register map and bit field definitions.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,6 +162,14 @@ npm run build
 - Layer switching and per-layer position control
 - Direct I2C register read/write
 
+## Versioning
+
+Hardware, fader firmware, and the ESPHome component version independently; `CHANGELOG.md`
+at the repo root holds the compatibility matrix and per-release notes. Update it when
+changing observable behaviour of any of the three, and bump `FW_VERSION_MINOR`
+(`firmware/src/shared/i2c_data.h`) or `FADER_BUDDY_COMPONENT_VERSION`
+(`esphome/components/fader_buddy/fader_buddy.h`) alongside.
+
 ## Architecture
 
 ### I2C Protocol
@@ -180,6 +188,10 @@ The FaderBuddy acts as an I2C peripheral with a configurable address (base 0x20 
   Three-byte writes behave exactly as before, so this is backwards compatible and did not
   bump the protocol version; send full-speed moves as 3-byte writes, since firmware
   predating the byte ignores a 4-byte write entirely
+- **Firmware version** (0x11): `REG_FW_VERSION`, a packed `(major << 8) | minor` u16, distinct
+  from the protocol version at 0x00. Hosts feature-detect on this; firmware predating it reads
+  back as 0xFFFF. The protocol version is only bumped when an existing register's wire format
+  changes, never for additive features. 0x10 is reserved for the I2C bootloader work
 - **Debug registers** (0xF0-0xF2): open-loop drive, control-loop internals, and runtime gain
   overrides. Compiled out unless `DEBUG_DRIVE` is defined, so they are absent from
   production builds. They sit at the top of the address space deliberately, so new

--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ fader_buddy:
 and to move the fader from a lambda:
 ```cpp
 id(my_fader).remote_move_to(position, layer);
+
+// optionally cap the speed - here, 500ms for a full-scale move
+id(my_fader).remote_move_to(position, layer, 500);
 ```
 
 That's pretty much all there is to it!

--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ and to move the fader from a lambda:
 ```cpp
 id(my_fader).remote_move_to(position, layer);
 
-// optionally cap the speed - here, 500ms for a full-scale move
-id(my_fader).remote_move_to(position, layer, 500);
+// optionally cap the speed - 0-255, where 255 is full speed
+id(my_fader).remote_move_to(position, layer, 128);
 ```
 
 That's pretty much all there is to it!

--- a/ci/util/check_i2c_data_sync.py
+++ b/ci/util/check_i2c_data_sync.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+#
+# Verifies that every copy of the I2C protocol header is byte-for-byte
+# identical to the canonical copy in firmware/src/shared/i2c_data.h.
+
+import difflib
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+CANONICAL = REPO_ROOT / 'firmware/src/shared/i2c_data.h'
+
+COPIES = [
+    REPO_ROOT / 'esphome/components/fader_buddy/i2c_data.h',
+]
+
+def main():
+    canonical_lines = CANONICAL.read_text().splitlines(keepends=True)
+
+    status = 0
+    for copy in COPIES:
+        copy_lines = copy.read_text().splitlines(keepends=True)
+        diff = list(difflib.unified_diff(
+            canonical_lines, copy_lines,
+            fromfile=str(CANONICAL), tofile=str(copy),
+        ))
+        if diff:
+            sys.stdout.writelines(diff)
+            print(f'error: {copy} has drifted from {CANONICAL}', file=sys.stderr)
+            status = 1
+
+    return status
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/esphome/components/fader_buddy/__init__.py
+++ b/esphome/components/fader_buddy/__init__.py
@@ -46,6 +46,7 @@ CONF_DETENT_COUNT = "detent_count"
 CONF_DETENT_STRENGTH = "detent_strength"
 CONF_POSITION = "position"
 CONF_VALUE_CHANGE_MIN_INTERVAL = "value_change_min_interval"
+CONF_MOVE_TIME = "move_time"
 
 # Schema for a single layer haptic configuration
 LAYER_HAPTIC_SCHEMA = cv.Schema({
@@ -143,6 +144,12 @@ async def set_active_layer_action_to_code(config, action_id, template_arg, args)
         cv.Required(CONF_ID): cv.use_id(FaderBuddy),
         cv.Required(CONF_POSITION): cv.templatable(cv.int_range(min=0, max=255)),
         cv.Optional(CONF_LAYER, default=0): cv.templatable(cv.int_range(min=0, max=7)),
+        # Time for a full-scale (0-255) move. Shorter moves take proportionally
+        # less time - this caps speed, it does not stretch the move to fill the
+        # duration. Default 0 means unlimited (move at full speed).
+        cv.Optional(CONF_MOVE_TIME, default="0ms"): cv.templatable(
+            cv.positive_time_period_milliseconds
+        ),
     })
 )
 async def remote_move_to_action_to_code(config, action_id, template_arg, args):
@@ -152,6 +159,8 @@ async def remote_move_to_action_to_code(config, action_id, template_arg, args):
     cg.add(var.set_position(position))
     layer = await cg.templatable(config[CONF_LAYER], args, cg.uint8)
     cg.add(var.set_layer(layer))
+    move_time = await cg.templatable(config[CONF_MOVE_TIME], args, cg.uint32)
+    cg.add(var.set_move_time(move_time))
     return var
 
 

--- a/esphome/components/fader_buddy/__init__.py
+++ b/esphome/components/fader_buddy/__init__.py
@@ -14,7 +14,7 @@
 from esphome import automation
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.components import i2c
+from esphome.components import button, i2c
 
 # Aliased: importing the sibling `text_sensor.py` platform module binds it as an
 # attribute of this package, which would shadow a plain `text_sensor` name here.
@@ -24,10 +24,13 @@ from esphome.core import CORE
 
 MULTI_CONF = True
 DEPENDENCIES = ["i2c"]
-AUTO_LOAD = ["text_sensor"]
+AUTO_LOAD = ["button", "text_sensor"]
 
 fader_buddy_ns = cg.esphome_ns.namespace("fader_buddy")
 FaderBuddy = fader_buddy_ns.class_("FaderBuddy", cg.PollingComponent, i2c.I2CDevice)
+SelfCalibrationButton = fader_buddy_ns.class_(
+    "SelfCalibrationButton", button.Button, cg.Parented.template(FaderBuddy)
+)
 
 # Used by platform files (e.g. text_sensor) to reference the parent hub
 CONF_FADER_BUDDY_ID = "fader_buddy_id"
@@ -55,6 +58,7 @@ CONF_SPEED = "speed"
 CONF_DEFAULT_SPEED = "default_speed"
 CONF_SERIAL_NUMBER = "serial_number"
 CONF_FIRMWARE_VERSION = "firmware_version"
+CONF_SELF_CALIBRATION = "self_calibration"
 
 # Diagnostic text sensors the hub creates itself, so a bare fader_buddy block
 # reports what it is without any entity yaml. Each maps to (default name
@@ -64,6 +68,14 @@ AUTO_TEXT_SENSORS = {
     CONF_SERIAL_NUMBER: ("Serial Number", "mdi:identifier"),
     CONF_FIRMWARE_VERSION: ("Firmware Version", "mdi:chip"),
 }
+
+# Buttons the hub creates itself, same deal. A press here moves the fader for
+# several seconds, so these are entity_category "config" rather than controls.
+AUTO_BUTTONS = {
+    CONF_SELF_CALIBRATION: ("Self Calibration", "mdi:tune-vertical"),
+}
+
+AUTO_ENTITIES = {**AUTO_TEXT_SENSORS, **AUTO_BUTTONS}
 
 
 def _default_entity_names(config):
@@ -82,7 +94,7 @@ def _default_entity_names(config):
         return config
     hub_id = config.get(CONF_ID)
     prefix = f"{hub_id} " if isinstance(hub_id, str) else ""
-    for key, (label, _icon) in AUTO_TEXT_SENSORS.items():
+    for key, (label, _icon) in AUTO_ENTITIES.items():
         sub = config.setdefault(key, {})
         if isinstance(sub, dict) and CONF_NAME not in sub:
             sub[CONF_NAME] = f"{prefix}{label}"
@@ -133,6 +145,11 @@ CONFIG_SCHEMA = cv.All(
             entity_category="diagnostic",
             icon=AUTO_TEXT_SENSORS[CONF_FIRMWARE_VERSION][1],
         ),
+        cv.Optional(CONF_SELF_CALIBRATION, default={}): button.button_schema(
+            SelfCalibrationButton,
+            entity_category="config",
+            icon=AUTO_BUTTONS[CONF_SELF_CALIBRATION][1],
+        ),
         cv.Optional(CONF_ON_MANUAL_MOVE): automation.validate_automation(single=True),
         cv.Optional(CONF_ON_RAW_POSITION_UPDATE): automation.validate_automation(single=True),
         cv.Optional(CONF_ON_TOUCH_CHANGE): automation.validate_automation(single=True),
@@ -158,6 +175,9 @@ async def to_code(config):
     if not _claimed_by_legacy_platform(config, CONF_FIRMWARE_VERSION):
         sens = await core_text_sensor.new_text_sensor(config[CONF_FIRMWARE_VERSION])
         cg.add(var.set_firmware_text_sensor(sens))
+
+    btn = await button.new_button(config[CONF_SELF_CALIBRATION])
+    await cg.register_parented(btn, config[CONF_ID])
 
     # Store initial layer haptic configurations (sent during setup)
     if CONF_LAYER_HAPTICS in config:

--- a/esphome/components/fader_buddy/__init__.py
+++ b/esphome/components/fader_buddy/__init__.py
@@ -46,7 +46,11 @@ CONF_DETENT_COUNT = "detent_count"
 CONF_DETENT_STRENGTH = "detent_strength"
 CONF_POSITION = "position"
 CONF_VALUE_CHANGE_MIN_INTERVAL = "value_change_min_interval"
-CONF_MOVE_TIME = "move_time"
+CONF_SPEED = "speed"
+CONF_DEFAULT_SPEED = "default_speed"
+
+# Unitless move speed: 255 is full speed, 0 the slowest smooth motion
+SPEED_FULL = 255
 
 # Schema for a single layer haptic configuration
 LAYER_HAPTIC_SCHEMA = cv.Schema({
@@ -55,6 +59,9 @@ LAYER_HAPTIC_SCHEMA = cv.Schema({
     cv.Optional(CONF_DETENT_COUNT, default=0): cv.int_range(min=0, max=15),
     cv.Optional(CONF_DETENT_STRENGTH, default=0): cv.int_range(min=0, max=7),
     cv.Optional(CONF_VALUE_CHANGE_MIN_INTERVAL, default="0ms"): cv.positive_time_period_milliseconds,
+    # Speed used for moves on this layer that don't name one. Kept host-side
+    # and sent with each move rather than stored on the fader.
+    cv.Optional(CONF_DEFAULT_SPEED, default=SPEED_FULL): cv.int_range(min=0, max=255),
 })
 
 CONFIG_SCHEMA = (
@@ -87,11 +94,13 @@ async def to_code(config):
             detent_count = haptic_config[CONF_DETENT_COUNT]
             detent_strength = haptic_config[CONF_DETENT_STRENGTH]
             min_interval = haptic_config[CONF_VALUE_CHANGE_MIN_INTERVAL]
+            default_speed = haptic_config[CONF_DEFAULT_SPEED]
 
             cg.add(var.store_initial_layer_haptic_config(
                 layer, mode, detent_count, detent_strength
             ))
             cg.add(var.set_layer_value_change_min_interval(layer, min_interval))
+            cg.add(var.set_layer_default_speed(layer, default_speed))
 
     if CONF_ON_MANUAL_MOVE in config:
         await automation.build_automation(
@@ -144,12 +153,11 @@ async def set_active_layer_action_to_code(config, action_id, template_arg, args)
         cv.Required(CONF_ID): cv.use_id(FaderBuddy),
         cv.Required(CONF_POSITION): cv.templatable(cv.int_range(min=0, max=255)),
         cv.Optional(CONF_LAYER, default=0): cv.templatable(cv.int_range(min=0, max=7)),
-        # Time for a full-scale (0-255) move. Shorter moves take proportionally
-        # less time - this caps speed, it does not stretch the move to fill the
-        # duration. Default 0 means unlimited (move at full speed).
-        cv.Optional(CONF_MOVE_TIME, default="0ms"): cv.templatable(
-            cv.positive_time_period_milliseconds
-        ),
+        # Unitless move speed, 0 (slowest smooth motion) to 255 (full speed).
+        # This caps speed, it does not stretch the move to fill a duration, so
+        # a shorter move takes proportionally less time. Omit it to use the
+        # layer's default_speed.
+        cv.Optional(CONF_SPEED): cv.templatable(cv.int_range(min=0, max=255)),
     })
 )
 async def remote_move_to_action_to_code(config, action_id, template_arg, args):
@@ -159,8 +167,9 @@ async def remote_move_to_action_to_code(config, action_id, template_arg, args):
     cg.add(var.set_position(position))
     layer = await cg.templatable(config[CONF_LAYER], args, cg.uint8)
     cg.add(var.set_layer(layer))
-    move_time = await cg.templatable(config[CONF_MOVE_TIME], args, cg.uint32)
-    cg.add(var.set_move_time(move_time))
+    if CONF_SPEED in config:
+        speed = await cg.templatable(config[CONF_SPEED], args, cg.uint8)
+        cg.add(var.set_speed(speed))
     return var
 
 

--- a/esphome/components/fader_buddy/__init__.py
+++ b/esphome/components/fader_buddy/__init__.py
@@ -15,7 +15,12 @@ from esphome import automation
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import i2c
-from esphome.const import CONF_ID, CONF_MODE
+
+# Aliased: importing the sibling `text_sensor.py` platform module binds it as an
+# attribute of this package, which would shadow a plain `text_sensor` name here.
+from esphome.components import text_sensor as core_text_sensor
+from esphome.const import CONF_ID, CONF_MODE, CONF_NAME
+from esphome.core import CORE
 
 MULTI_CONF = True
 DEPENDENCIES = ["i2c"]
@@ -48,6 +53,58 @@ CONF_POSITION = "position"
 CONF_VALUE_CHANGE_MIN_INTERVAL = "value_change_min_interval"
 CONF_SPEED = "speed"
 CONF_DEFAULT_SPEED = "default_speed"
+CONF_SERIAL_NUMBER = "serial_number"
+CONF_FIRMWARE_VERSION = "firmware_version"
+
+# Diagnostic text sensors the hub creates itself, so a bare fader_buddy block
+# reports what it is without any entity yaml. Each maps to (default name
+# suffix, icon). Set `internal: true` on one to keep it out of Home Assistant,
+# or `disabled_by_default: true` to have HA register it but leave it off.
+AUTO_TEXT_SENSORS = {
+    CONF_SERIAL_NUMBER: ("Serial Number", "mdi:identifier"),
+    CONF_FIRMWARE_VERSION: ("Firmware Version", "mdi:chip"),
+}
+
+
+def _default_entity_names(config):
+    """Give each auto-created text sensor a name before its schema validates.
+
+    The entity base schema rejects a sub-config carrying neither `name:` nor a
+    manual `id:`, and it runs while validating that sub-config - before any
+    validator on this schema could fill one in. So this has to be a
+    pre-validator, seeing the raw config.
+
+    The name is prefixed with the hub's id so several faders in one device don't
+    collide. A config with multiple hubs and no ids on them would; ESPHome's
+    auto-generated ids don't exist yet at this point.
+    """
+    if not isinstance(config, dict):
+        return config
+    hub_id = config.get(CONF_ID)
+    prefix = f"{hub_id} " if isinstance(hub_id, str) else ""
+    for key, (label, _icon) in AUTO_TEXT_SENSORS.items():
+        sub = config.setdefault(key, {})
+        if isinstance(sub, dict) and CONF_NAME not in sub:
+            sub[CONF_NAME] = f"{prefix}{label}"
+    return config
+
+
+def _claimed_by_legacy_platform(config, key):
+    """True if a `text_sensor: platform: fader_buddy` block already provides this.
+
+    The deprecated platform form calls the same setter, so without this check a
+    config using it would get two entities for one sensor - the hub's own, left
+    unpublished, and the platform's. Drop the hub's in that case, so migrating
+    is a pure deletion of the old block.
+    """
+    for entry in CORE.config.get("text_sensor", []):
+        if entry.get("platform") != "fader_buddy":
+            continue
+        if entry.get(CONF_FADER_BUDDY_ID) != config[CONF_ID]:
+            continue
+        if key in entry:
+            return True
+    return False
 
 # Unitless move speed: 255 is full speed, 0 the slowest smooth motion
 SPEED_FULL = 255
@@ -64,9 +121,18 @@ LAYER_HAPTIC_SCHEMA = cv.Schema({
     cv.Optional(CONF_DEFAULT_SPEED, default=SPEED_FULL): cv.int_range(min=0, max=255),
 })
 
-CONFIG_SCHEMA = (
+CONFIG_SCHEMA = cv.All(
+    _default_entity_names,
     cv.Schema({
         cv.GenerateID(): cv.declare_id(FaderBuddy),
+        cv.Optional(CONF_SERIAL_NUMBER, default={}): core_text_sensor.text_sensor_schema(
+            entity_category="diagnostic",
+            icon=AUTO_TEXT_SENSORS[CONF_SERIAL_NUMBER][1],
+        ),
+        cv.Optional(CONF_FIRMWARE_VERSION, default={}): core_text_sensor.text_sensor_schema(
+            entity_category="diagnostic",
+            icon=AUTO_TEXT_SENSORS[CONF_FIRMWARE_VERSION][1],
+        ),
         cv.Optional(CONF_ON_MANUAL_MOVE): automation.validate_automation(single=True),
         cv.Optional(CONF_ON_RAW_POSITION_UPDATE): automation.validate_automation(single=True),
         cv.Optional(CONF_ON_TOUCH_CHANGE): automation.validate_automation(single=True),
@@ -75,7 +141,7 @@ CONFIG_SCHEMA = (
         cv.Optional(CONF_LAYER_HAPTICS): cv.ensure_list(LAYER_HAPTIC_SCHEMA),
     })
     .extend(cv.polling_component_schema("50ms"))
-    .extend(i2c.i2c_device_schema(0x20))  # default I2C address
+    .extend(i2c.i2c_device_schema(0x20)),  # default I2C address
 )
 
 async def to_code(config):
@@ -85,6 +151,13 @@ async def to_code(config):
 
     if CONF_INVERT in config:
         cg.add(var.set_invert(config[CONF_INVERT]))
+
+    if not _claimed_by_legacy_platform(config, CONF_SERIAL_NUMBER):
+        sens = await core_text_sensor.new_text_sensor(config[CONF_SERIAL_NUMBER])
+        cg.add(var.set_serial_text_sensor(sens))
+    if not _claimed_by_legacy_platform(config, CONF_FIRMWARE_VERSION):
+        sens = await core_text_sensor.new_text_sensor(config[CONF_FIRMWARE_VERSION])
+        cg.add(var.set_firmware_text_sensor(sens))
 
     # Store initial layer haptic configurations (sent during setup)
     if CONF_LAYER_HAPTICS in config:

--- a/esphome/components/fader_buddy/fader_buddy.cpp
+++ b/esphome/components/fader_buddy/fader_buddy.cpp
@@ -239,7 +239,7 @@ uint8_t FaderBuddy::get_active_layer() const {
 // Move fader to a specific position (Protocol v5: use REG_LAYER_TARGET)
 // position: USER-FACING position (0-255)
 // layer: which layer to move (0-7)
-void FaderBuddy::remote_move_to(uint8_t position, uint8_t layer) {
+void FaderBuddy::remote_move_to(uint8_t position, uint8_t layer, uint32_t move_time_ms) {
   if (layer > 7) {
     ESP_LOGE(TAG, "Invalid layer index: %d", layer);
     return;
@@ -248,10 +248,33 @@ void FaderBuddy::remote_move_to(uint8_t position, uint8_t layer) {
   // Convert USER-FACING position to HARDWARE position
   uint8_t hw_position = invert_ ? (255 - position) : position;
 
-  // Write to firmware using layer-addressed protocol
-  uint8_t buffer[] = {REG_LAYER_TARGET, layer, hw_position};
-  if (write_with_retry_(buffer, 3)) {
-    ESP_LOGD(TAG, "Set layer %d target to %d (user position)", layer, position);
+  // Write to firmware using layer-addressed protocol. Without a move time this
+  // is the original 3-byte write, which older firmware also accepts.
+  if (move_time_ms == 0) {
+    uint8_t buffer[] = {REG_LAYER_TARGET, layer, hw_position};
+    if (write_with_retry_(buffer, 3)) {
+      ESP_LOGD(TAG, "Set layer %d target to %d (user position)", layer, position);
+    } else {
+      ESP_LOGE(TAG, "Failed to write layer %d target", layer);
+    }
+    return;
+  }
+
+  // Encode as the firmware's 10 ms units, clamped to the representable range
+  uint32_t units = (move_time_ms + LAYER_MOVE_TIME_MS_PER_UNIT / 2) / LAYER_MOVE_TIME_MS_PER_UNIT;
+  if (units < 1) {
+    units = 1;
+  }
+  if (units > 255) {
+    ESP_LOGW(TAG, "move_time %ums exceeds the maximum of %ums; clamping", move_time_ms,
+             255 * LAYER_MOVE_TIME_MS_PER_UNIT);
+    units = 255;
+  }
+
+  uint8_t buffer[] = {REG_LAYER_TARGET, layer, hw_position, (uint8_t) units};
+  if (write_with_retry_(buffer, 4)) {
+    ESP_LOGD(TAG, "Set layer %d target to %d (user position), full-scale move time %ums", layer,
+             position, (unsigned) (units * LAYER_MOVE_TIME_MS_PER_UNIT));
   } else {
     ESP_LOGE(TAG, "Failed to write layer %d target", layer);
   }

--- a/esphome/components/fader_buddy/fader_buddy.cpp
+++ b/esphome/components/fader_buddy/fader_buddy.cpp
@@ -15,6 +15,8 @@
 
 #include "fader_buddy.h"
 
+#include <cstdio>
+
 #include "esphome/core/application.h"
 #include "esphome/core/log.h"
 
@@ -114,6 +116,7 @@ void FaderBuddy::dump_config() {
     ESP_LOGCONFIG(TAG, "  Serial Number: %s", this->serial_number_.c_str());
   }
   LOG_TEXT_SENSOR("  ", "Serial Number", this->serial_text_sensor_);
+  LOG_TEXT_SENSOR("  ", "Firmware Version", this->firmware_text_sensor_);
 
   LOG_UPDATE_INTERVAL(this);
 }
@@ -156,12 +159,21 @@ void FaderBuddy::read_firmware_version_() {
     this->firmware_version_ = ((uint16_t) buffer[0] << 8) | buffer[1];
   }
 
+  char version[16];
   if (this->firmware_version_ == FW_VERSION_NONE || this->firmware_version_ == 0) {
     this->firmware_version_ = FW_VERSION_NONE;
-    ESP_LOGCONFIG(TAG, "Fader firmware: 1.0 or older (no version register)");
+    // Pre-1.1 firmware has no version register, so this is the most specific
+    // thing that can be said about it.
+    snprintf(version, sizeof(version), "1.0 or older");
+    ESP_LOGCONFIG(TAG, "Fader firmware: %s (no version register)", version);
   } else {
-    ESP_LOGCONFIG(TAG, "Fader firmware: %d.%d", this->firmware_version_ >> 8,
-                  this->firmware_version_ & 0xFF);
+    snprintf(version, sizeof(version), "%d.%d", this->firmware_version_ >> 8,
+             this->firmware_version_ & 0xFF);
+    ESP_LOGCONFIG(TAG, "Fader firmware: %s", version);
+  }
+
+  if (this->firmware_text_sensor_ != nullptr) {
+    this->firmware_text_sensor_->publish_state(version);
   }
 
   this->speed_supported_ = this->firmware_version_ != FW_VERSION_NONE &&

--- a/esphome/components/fader_buddy/fader_buddy.cpp
+++ b/esphome/components/fader_buddy/fader_buddy.cpp
@@ -249,6 +249,33 @@ bool FaderBuddy::read_sensor_data_() {
   uint8_t double_tap_nonce = (state & STATE_DOUBLE_TAP_NONCE_bm) >> STATE_DOUBLE_TAP_NONCE_bp;
   uint8_t active_layer = (state & STATE_ACTIVE_LAYER_bm) >> STATE_ACTIVE_LAYER_bp;
 
+  // The fader's mode changes on its own - self-calibration finishing, a move
+  // timing out into MODE_ERROR - and nothing else here reports that.
+  if (mode != this->last_mode_) {
+    Mode previous = this->last_mode_;
+    this->last_mode_ = mode;
+
+    if (mode == MODE_SELF_CALIBRATION) {
+      ESP_LOGI(TAG, "Self-calibration started");
+    } else if (previous == MODE_SELF_CALIBRATION) {
+      if (mode == MODE_ERROR) {
+        ESP_LOGE(TAG, "Self-calibration failed: the endpoint sweep found no usable travel. "
+                      "Check the motor and potentiometer wiring. The fader ignores position "
+                      "commands until the error is cleared.");
+      } else {
+        // Re-read what it measured. The startup log ran before this, so these
+        // are the only numbers that reflect the run that just finished.
+        ESP_LOGI(TAG, "Self-calibration complete");
+        this->read_motor_calibration_();
+      }
+    } else if (mode == MODE_ERROR) {
+      ESP_LOGW(TAG, "Fader latched MODE_ERROR (a move did not reach its target). "
+                    "Position commands are ignored until the error is cleared.");
+    } else {
+      ESP_LOGD(TAG, "Mode %d -> %d", previous, mode);
+    }
+  }
+
   if (state != last_state_) {
     last_state_ = state;
     // ESP_LOGD(TAG, "State: %08x -- Current position: %03d, position_nonce: %d, touch: %01d, mode: %d, adc: %d, double_tap_nonce: %d\n", (unsigned int) state, hw_position, position_nonce, touch, mode, raw_adc, double_tap_nonce);

--- a/esphome/components/fader_buddy/fader_buddy.cpp
+++ b/esphome/components/fader_buddy/fader_buddy.cpp
@@ -239,7 +239,17 @@ uint8_t FaderBuddy::get_active_layer() const {
 // Move fader to a specific position (Protocol v5: use REG_LAYER_TARGET)
 // position: USER-FACING position (0-255)
 // layer: which layer to move (0-7)
-void FaderBuddy::remote_move_to(uint8_t position, uint8_t layer, uint32_t move_time_ms) {
+// Uses the layer's configured default speed.
+void FaderBuddy::remote_move_to(uint8_t position, uint8_t layer) {
+  if (layer > 7) {
+    ESP_LOGE(TAG, "Invalid layer index: %d", layer);
+    return;
+  }
+  this->remote_move_to(position, layer, layer_states_[layer].default_speed);
+}
+
+// speed: unitless 0-255 (LAYER_SPEED_FULL = full speed, 0 = slowest smooth motion)
+void FaderBuddy::remote_move_to(uint8_t position, uint8_t layer, uint8_t speed) {
   if (layer > 7) {
     ESP_LOGE(TAG, "Invalid layer index: %d", layer);
     return;
@@ -248,33 +258,13 @@ void FaderBuddy::remote_move_to(uint8_t position, uint8_t layer, uint32_t move_t
   // Convert USER-FACING position to HARDWARE position
   uint8_t hw_position = invert_ ? (255 - position) : position;
 
-  // Write to firmware using layer-addressed protocol. Without a move time this
-  // is the original 3-byte write, which older firmware also accepts.
-  if (move_time_ms == 0) {
-    uint8_t buffer[] = {REG_LAYER_TARGET, layer, hw_position};
-    if (write_with_retry_(buffer, 3)) {
-      ESP_LOGD(TAG, "Set layer %d target to %d (user position)", layer, position);
-    } else {
-      ESP_LOGE(TAG, "Failed to write layer %d target", layer);
-    }
-    return;
-  }
-
-  // Encode as the firmware's 10 ms units, clamped to the representable range
-  uint32_t units = (move_time_ms + LAYER_MOVE_TIME_MS_PER_UNIT / 2) / LAYER_MOVE_TIME_MS_PER_UNIT;
-  if (units < 1) {
-    units = 1;
-  }
-  if (units > 255) {
-    ESP_LOGW(TAG, "move_time %ums exceeds the maximum of %ums; clamping", move_time_ms,
-             255 * LAYER_MOVE_TIME_MS_PER_UNIT);
-    units = 255;
-  }
-
-  uint8_t buffer[] = {REG_LAYER_TARGET, layer, hw_position, (uint8_t) units};
-  if (write_with_retry_(buffer, 4)) {
-    ESP_LOGD(TAG, "Set layer %d target to %d (user position), full-scale move time %ums", layer,
-             position, (unsigned) (units * LAYER_MOVE_TIME_MS_PER_UNIT));
+  // Write to firmware using layer-addressed protocol. At full speed send the
+  // original 3-byte write: it is equivalent, and firmware predating the speed
+  // byte ignores a 4-byte write entirely rather than moving.
+  uint8_t buffer[] = {REG_LAYER_TARGET, layer, hw_position, speed};
+  size_t len = (speed == LAYER_SPEED_FULL) ? 3 : 4;
+  if (write_with_retry_(buffer, len)) {
+    ESP_LOGD(TAG, "Set layer %d target to %d (user position) at speed %d", layer, position, speed);
   } else {
     ESP_LOGE(TAG, "Failed to write layer %d target", layer);
   }
@@ -386,6 +376,21 @@ void FaderBuddy::set_layer_value_change_min_interval(uint8_t layer, uint32_t min
     return;
   }
   layer_states_[layer].value_change_min_interval = min_interval_ms;
+}
+
+void FaderBuddy::set_layer_default_speed(uint8_t layer, uint8_t speed) {
+  if (layer > 7) {
+    ESP_LOGE(TAG, "Invalid layer index: %d", layer);
+    return;
+  }
+  layer_states_[layer].default_speed = speed;
+}
+
+uint8_t FaderBuddy::get_layer_default_speed(uint8_t layer) const {
+  if (layer > 7) {
+    return LAYER_SPEED_FULL;
+  }
+  return layer_states_[layer].default_speed;
 }
 
 void FaderBuddy::run_self_calibration() {

--- a/esphome/components/fader_buddy/fader_buddy.cpp
+++ b/esphome/components/fader_buddy/fader_buddy.cpp
@@ -393,11 +393,14 @@ void FaderBuddy::remote_move_to(uint8_t position, uint8_t layer, uint8_t speed) 
     speed = LAYER_SPEED_FULL;
   }
 
-  // Write to firmware using layer-addressed protocol. At full speed send the
-  // original 3-byte write: it is equivalent, and firmware predating the speed
-  // byte ignores a 4-byte write entirely rather than moving.
+  // Always send the speed when the firmware understands it, full speed
+  // included. A 3-byte write leaves the layer's STORED speed alone, so after
+  // any slower move it would silently re-apply that old limit - it is only
+  // equivalent to a full-speed move if the layer was already at full speed.
+  // Firmware predating the byte ignores a 4-byte write entirely, so that case
+  // (where speed has been forced to LAYER_SPEED_FULL above) still sends 3.
   uint8_t buffer[] = {REG_LAYER_TARGET, layer, hw_position, speed};
-  size_t len = (speed == LAYER_SPEED_FULL) ? 3 : 4;
+  size_t len = speed_supported_ ? 4 : 3;
   if (write_with_retry_(buffer, len)) {
     ESP_LOGD(TAG, "Set layer %d target to %d (user position) at speed %d", layer, position, speed);
   } else {

--- a/esphome/components/fader_buddy/fader_buddy.cpp
+++ b/esphome/components/fader_buddy/fader_buddy.cpp
@@ -42,16 +42,40 @@ void FaderBuddy::setup() {
     return;
   }
 
-  if (buffer != I2C_PROTOCOL_VERSION) {
-    ESP_LOGE(TAG, "Init: Incompatible I2C protocol version. Expected %d but got %d", I2C_PROTOCOL_VERSION, buffer);
+  // Older protocols really are incompatible - the register layout differs - but
+  // a NEWER one is not, because bumps are only made for changes a host can
+  // ignore. Failing on those would brick this host on a fader that merely got
+  // updated, so warn and carry on instead.
+  if (buffer < I2C_PROTOCOL_VERSION) {
+    ESP_LOGE(TAG, "Init: Incompatible I2C protocol version. Expected at least %d but got %d",
+             I2C_PROTOCOL_VERSION, buffer);
     this->mark_failed();
     return;
   }
+  if (buffer > I2C_PROTOCOL_VERSION) {
+    ESP_LOGW(TAG, "Fader reports protocol v%d, newer than the v%d this component was built against. "
+                  "Continuing, but consider updating the component.", buffer, I2C_PROTOCOL_VERSION);
+  }
 
-  ESP_LOGCONFIG(TAG, "FaderBuddy initialized (protocol v%d)", buffer);
+  ESP_LOGCONFIG(TAG, "FaderBuddy initialized (component %s, protocol v%d)",
+                FADER_BUDDY_COMPONENT_VERSION, buffer);
 
   // Read the chip serial number once (static factory ID) and publish it.
   read_serial_number_();
+  read_firmware_version_();
+
+  // Flag a config that asks for something this fader's firmware cannot do, at
+  // startup rather than waiting for the first move to warn.
+  if (!speed_supported_) {
+    for (uint8_t i = 0; i < 8; i++) {
+      if (layer_states_[i].default_speed != LAYER_SPEED_FULL) {
+        ESP_LOGW(TAG, "Layer %d sets default_speed, but this fader's firmware does not support move "
+                      "speed. Moves will run at full speed. Update the fader firmware to %d.%d or newer.",
+                 i, FW_VERSION_MOVE_SPEED >> 8, FW_VERSION_MOVE_SPEED & 0xFF);
+        break;
+      }
+    }
+  }
 
   // Send initial haptic configurations to firmware
   for (uint8_t i = 0; i < 8; i++) {
@@ -75,6 +99,14 @@ void FaderBuddy::dump_config() {
   LOG_I2C_DEVICE(this);
   if (this->is_failed()) {
     ESP_LOGE(TAG, "Communication failed");
+  }
+
+  ESP_LOGCONFIG(TAG, "  Component Version: %s", FADER_BUDDY_COMPONENT_VERSION);
+  if (this->firmware_version_ == FW_VERSION_NONE) {
+    ESP_LOGCONFIG(TAG, "  Firmware Version: 1.0 or older (does not report a version)");
+  } else {
+    ESP_LOGCONFIG(TAG, "  Firmware Version: %d.%d", this->firmware_version_ >> 8,
+                  this->firmware_version_ & 0xFF);
   }
 
   if (!this->serial_number_.empty()) {
@@ -106,6 +138,33 @@ void FaderBuddy::read_serial_number_() {
   if (this->serial_text_sensor_ != nullptr) {
     this->serial_text_sensor_->publish_state(this->serial_number_);
   }
+}
+
+// Read the reported firmware version and derive what this fader can do.
+// Firmware predating the register leaves the bus undriven, so the read
+// succeeds and returns 0xFFFF rather than failing - hence checking the value,
+// not just the error code.
+void FaderBuddy::read_firmware_version_() {
+  uint8_t reg = REG_FW_VERSION;
+  uint8_t buffer[2] = {0xFF, 0xFF};
+  auto read_result = this->write_read(&reg, 1, buffer, sizeof(buffer));
+  if (read_result != esphome::i2c::ErrorCode::NO_ERROR) {
+    ESP_LOGW(TAG, "Failed to read firmware version: %d; assuming pre-1.1 firmware", read_result);
+    this->firmware_version_ = FW_VERSION_NONE;
+  } else {
+    this->firmware_version_ = ((uint16_t) buffer[0] << 8) | buffer[1];
+  }
+
+  if (this->firmware_version_ == FW_VERSION_NONE || this->firmware_version_ == 0) {
+    this->firmware_version_ = FW_VERSION_NONE;
+    ESP_LOGCONFIG(TAG, "Fader firmware: 1.0 or older (no version register)");
+  } else {
+    ESP_LOGCONFIG(TAG, "Fader firmware: %d.%d", this->firmware_version_ >> 8,
+                  this->firmware_version_ & 0xFF);
+  }
+
+  this->speed_supported_ = this->firmware_version_ != FW_VERSION_NONE &&
+                           this->firmware_version_ >= FW_VERSION_MOVE_SPEED;
 }
 
 float FaderBuddy::get_setup_priority() const { return setup_priority::DATA; }
@@ -257,6 +316,19 @@ void FaderBuddy::remote_move_to(uint8_t position, uint8_t layer, uint8_t speed) 
 
   // Convert USER-FACING position to HARDWARE position
   uint8_t hw_position = invert_ ? (255 - position) : position;
+
+  // Firmware without the speed byte drops a 4-byte write entirely, so fall
+  // back to a full-speed move rather than letting the fader not move at all.
+  if (speed != LAYER_SPEED_FULL && !speed_supported_) {
+    if (!warned_speed_unsupported_) {
+      warned_speed_unsupported_ = true;
+      ESP_LOGW(TAG, "Requested move speed %d, but this fader's firmware does not support it "
+                    "(needs %d.%d or newer). Moving at full speed instead. "
+                    "This warning is logged once.",
+               speed, FW_VERSION_MOVE_SPEED >> 8, FW_VERSION_MOVE_SPEED & 0xFF);
+    }
+    speed = LAYER_SPEED_FULL;
+  }
 
   // Write to firmware using layer-addressed protocol. At full speed send the
   // original 3-byte write: it is equivalent, and firmware predating the speed

--- a/esphome/components/fader_buddy/fader_buddy.cpp
+++ b/esphome/components/fader_buddy/fader_buddy.cpp
@@ -63,6 +63,7 @@ void FaderBuddy::setup() {
   // Read the chip serial number once (static factory ID) and publish it.
   read_serial_number_();
   read_firmware_version_();
+  read_motor_calibration_();
 
   // Flag a config that asks for something this fader's firmware cannot do, at
   // startup rather than waiting for the first move to warn.
@@ -165,6 +166,41 @@ void FaderBuddy::read_firmware_version_() {
 
   this->speed_supported_ = this->firmware_version_ != FW_VERSION_NONE &&
                            this->firmware_version_ >= FW_VERSION_MOVE_SPEED;
+}
+
+// Log what self-calibration measured about this fader's motor, and the
+// feedforward it derived. Diagnostic only - the fader needs nothing from the
+// host here - but these are the numbers to look at when a fader hunts or
+// settles slowly, and on a bench with no test jig attached this log is the
+// only way to see them.
+void FaderBuddy::read_motor_calibration_() {
+  if (this->firmware_version_ == FW_VERSION_NONE ||
+      this->firmware_version_ < FW_VERSION_MOTOR_CAL) {
+    return;  // Older firmware has no such register; nothing to report
+  }
+
+  uint8_t reg = REG_MOTOR_CAL;
+  uint8_t b[12] = {0};
+  if (this->write_read(&reg, 1, b, sizeof(b)) != esphome::i2c::ErrorCode::NO_ERROR) {
+    ESP_LOGW(TAG, "Failed to read motor calibration");
+    return;
+  }
+
+  uint16_t vel_min = ((uint16_t) b[9] << 8) | b[10];
+
+  if (b[0] == 0) {
+    ESP_LOGCONFIG(TAG, "Motor: not characterised, using the default plant model "
+                       "(vel_min %u ADC/s, deadband %d). Run self-calibration to measure this unit.",
+                  vel_min, b[11]);
+    return;
+  }
+
+  ESP_LOGCONFIG(TAG, "Motor: breakaway %d/%d duty, k %d/%d ADC/s per duty, "
+                     "jump %u/%u ADC/s (rising/falling)",
+                b[1], b[2], b[3], b[4],
+                ((uint16_t) b[5] << 8) | b[6], ((uint16_t) b[7] << 8) | b[8]);
+  ESP_LOGCONFIG(TAG, "Motor: vel_min %u ADC/s, deadband %d ADC counts",
+                vel_min, b[11]);
 }
 
 float FaderBuddy::get_setup_priority() const { return setup_priority::DATA; }

--- a/esphome/components/fader_buddy/fader_buddy.h
+++ b/esphome/components/fader_buddy/fader_buddy.h
@@ -44,7 +44,11 @@ class FaderBuddy : public PollingComponent, public i2c::I2CDevice {
     // Layer management (Protocol v5: forwards to firmware)
     void set_active_layer(uint8_t layer_index);
     uint8_t get_active_layer() const;
-    void remote_move_to(uint8_t position, uint8_t layer = 0);
+    // move_time_ms: how long a full-scale (0-255) move should take. 0 leaves
+    // the layer's existing limit alone and moves at full speed by default.
+    // Shorter moves take proportionally less time - it is a speed cap, not a
+    // duration the move is stretched to fill.
+    void remote_move_to(uint8_t position, uint8_t layer = 0, uint32_t move_time_ms = 0);
     uint8_t get_position(uint8_t layer = 0) const;
     void set_layer_haptic_config(
         uint8_t layer,
@@ -133,9 +137,11 @@ template<typename... Ts> class RemoteMoveToAction : public Action<Ts...> {
 
   TEMPLATABLE_VALUE(uint8_t, position)
   TEMPLATABLE_VALUE(uint8_t, layer)
+  TEMPLATABLE_VALUE(uint32_t, move_time)
 
   void play(const Ts &...x) override {
-    this->parent_->remote_move_to(this->position_.value(x...), this->layer_.value(x...));
+    this->parent_->remote_move_to(this->position_.value(x...), this->layer_.value(x...),
+                                  this->move_time_.value(x...));
   }
 
  protected:

--- a/esphome/components/fader_buddy/fader_buddy.h
+++ b/esphome/components/fader_buddy/fader_buddy.h
@@ -21,6 +21,8 @@
 #include "esphome/core/automation.h"
 #include "esphome/core/optional.h"
 
+#include "i2c_data.h"
+
 #include <string>
 
 namespace esphome {
@@ -44,11 +46,12 @@ class FaderBuddy : public PollingComponent, public i2c::I2CDevice {
     // Layer management (Protocol v5: forwards to firmware)
     void set_active_layer(uint8_t layer_index);
     uint8_t get_active_layer() const;
-    // move_time_ms: how long a full-scale (0-255) move should take. 0 leaves
-    // the layer's existing limit alone and moves at full speed by default.
-    // Shorter moves take proportionally less time - it is a speed cap, not a
-    // duration the move is stretched to fill.
-    void remote_move_to(uint8_t position, uint8_t layer = 0, uint32_t move_time_ms = 0);
+    // Moves at the layer's configured default speed (see set_layer_default_speed).
+    void remote_move_to(uint8_t position, uint8_t layer = 0);
+    // speed: unitless 0-255, where LAYER_SPEED_FULL (255) is full speed and 0
+    // is the slowest the fader moves smoothly. It caps speed rather than
+    // scheduling the move, so a shorter move takes proportionally less time.
+    void remote_move_to(uint8_t position, uint8_t layer, uint8_t speed);
     uint8_t get_position(uint8_t layer = 0) const;
     void set_layer_haptic_config(
         uint8_t layer,
@@ -60,6 +63,12 @@ class FaderBuddy : public PollingComponent, public i2c::I2CDevice {
     void run_self_calibration();
     void set_invert(bool invert) { invert_ = invert; }
     void set_layer_value_change_min_interval(uint8_t layer, uint32_t min_interval_ms);
+    // Speed used for moves on this layer when the caller doesn't name one.
+    // Tracked host-side and sent with each move, rather than pushed to the
+    // fader as configuration, so a layer's default costs no extra I2C traffic
+    // and needs no round trip to change.
+    void set_layer_default_speed(uint8_t layer, uint8_t speed);
+    uint8_t get_layer_default_speed(uint8_t layer) const;
 
     // Chip serial number (10-byte factory ID, read once at setup). Returns an
     // uppercase hex string (e.g. "AABBCCDDEEFF00112233"), or "" if not yet read.
@@ -104,6 +113,7 @@ class FaderBuddy : public PollingComponent, public i2c::I2CDevice {
             bool has_deferred_value{false};
             uint16_t last_hw_position{0};  // Last HARDWARE position from firmware (0-255, raw from I2C)
             uint8_t last_position_nonce{0};
+            uint8_t default_speed{LAYER_SPEED_FULL};  // speed for moves that don't name one
         };
         LayerState layer_states_[8] = {};
 
@@ -137,11 +147,18 @@ template<typename... Ts> class RemoteMoveToAction : public Action<Ts...> {
 
   TEMPLATABLE_VALUE(uint8_t, position)
   TEMPLATABLE_VALUE(uint8_t, layer)
-  TEMPLATABLE_VALUE(uint32_t, move_time)
+  TEMPLATABLE_VALUE(uint8_t, speed)
 
   void play(const Ts &...x) override {
-    this->parent_->remote_move_to(this->position_.value(x...), this->layer_.value(x...),
-                                  this->move_time_.value(x...));
+    uint8_t position = this->position_.value(x...);
+    uint8_t layer = this->layer_.value(x...);
+    // An unset speed means "whatever this layer is configured to use", which
+    // is not the same as any particular value the caller could pass.
+    if (this->speed_.has_value()) {
+      this->parent_->remote_move_to(position, layer, this->speed_.value(x...));
+    } else {
+      this->parent_->remote_move_to(position, layer);
+    }
   }
 
  protected:

--- a/esphome/components/fader_buddy/fader_buddy.h
+++ b/esphome/components/fader_buddy/fader_buddy.h
@@ -109,6 +109,10 @@ class FaderBuddy : public PollingComponent, public i2c::I2CDevice {
 
         // State variables
         uint32_t last_state_{0};
+        // Faders normally come up idle, so this doesn't log a phantom
+        // transition at startup - but a fader that boots into MODE_ERROR does
+        // get reported, which is what we want.
+        Mode last_mode_{MODE_INPUT_IDLE};
         std::string serial_number_;
         text_sensor::TextSensor *serial_text_sensor_{nullptr};
         HighFrequencyLoopRequester high_freq_;

--- a/esphome/components/fader_buddy/fader_buddy.h
+++ b/esphome/components/fader_buddy/fader_buddy.h
@@ -30,7 +30,7 @@ namespace fader_buddy {
 
 // Version of this ESPHome component, independent of the fader's firmware
 // version. Logged at startup so a bug report identifies both halves.
-#define FADER_BUDDY_COMPONENT_VERSION "0.2.0"
+#define FADER_BUDDY_COMPONENT_VERSION "0.3.0"
 
 
 // Protocol v5: Layer management is now handled in firmware
@@ -105,6 +105,7 @@ class FaderBuddy : public PollingComponent, public i2c::I2CDevice {
     private:
         void read_serial_number_();
         void read_firmware_version_();
+        void read_motor_calibration_();
 
         // State variables
         uint32_t last_state_{0};

--- a/esphome/components/fader_buddy/fader_buddy.h
+++ b/esphome/components/fader_buddy/fader_buddy.h
@@ -83,6 +83,7 @@ class FaderBuddy : public PollingComponent, public i2c::I2CDevice {
     // uppercase hex string (e.g. "AABBCCDDEEFF00112233"), or "" if not yet read.
     std::string get_serial_number() const { return serial_number_; }
     void set_serial_text_sensor(text_sensor::TextSensor *s) { serial_text_sensor_ = s; }
+    void set_firmware_text_sensor(text_sensor::TextSensor *s) { firmware_text_sensor_ = s; }
 
     // Called only from codegen to store initial haptic configs
     void store_initial_layer_haptic_config(uint8_t layer, uint8_t mode, uint8_t detent_count, uint8_t detent_strength);
@@ -115,6 +116,7 @@ class FaderBuddy : public PollingComponent, public i2c::I2CDevice {
         Mode last_mode_{MODE_INPUT_IDLE};
         std::string serial_number_;
         text_sensor::TextSensor *serial_text_sensor_{nullptr};
+        text_sensor::TextSensor *firmware_text_sensor_{nullptr};
         HighFrequencyLoopRequester high_freq_;
         bool invert_{false};
         bool last_touch_{false};

--- a/esphome/components/fader_buddy/fader_buddy.h
+++ b/esphome/components/fader_buddy/fader_buddy.h
@@ -28,6 +28,11 @@
 namespace esphome {
 namespace fader_buddy {
 
+// Version of this ESPHome component, independent of the fader's firmware
+// version. Logged at startup so a bug report identifies both halves.
+#define FADER_BUDDY_COMPONENT_VERSION "0.2.0"
+
+
 // Protocol v5: Layer management is now handled in firmware
 // ESPHome component is a simple protocol wrapper
 
@@ -70,6 +75,10 @@ class FaderBuddy : public PollingComponent, public i2c::I2CDevice {
     void set_layer_default_speed(uint8_t layer, uint8_t speed);
     uint8_t get_layer_default_speed(uint8_t layer) const;
 
+    // Firmware version reported by the fader, packed as (major << 8) | minor.
+    // FW_VERSION_NONE for firmware old enough to have no version register.
+    uint16_t get_firmware_version() const { return firmware_version_; }
+
     // Chip serial number (10-byte factory ID, read once at setup). Returns an
     // uppercase hex string (e.g. "AABBCCDDEEFF00112233"), or "" if not yet read.
     std::string get_serial_number() const { return serial_number_; }
@@ -95,6 +104,7 @@ class FaderBuddy : public PollingComponent, public i2c::I2CDevice {
 
     private:
         void read_serial_number_();
+        void read_firmware_version_();
 
         // State variables
         uint32_t last_state_{0};
@@ -104,6 +114,9 @@ class FaderBuddy : public PollingComponent, public i2c::I2CDevice {
         bool invert_{false};
         bool last_touch_{false};
         uint8_t last_double_tap_nonce_{0};
+        uint16_t firmware_version_{FW_VERSION_NONE};
+        bool speed_supported_{false};
+        bool warned_speed_unsupported_{false};  // warn once, not once per move
 
         // Per-layer state for value change rate limiting and position tracking
         struct LayerState {

--- a/esphome/components/fader_buddy/fader_buddy.h
+++ b/esphome/components/fader_buddy/fader_buddy.h
@@ -16,9 +16,11 @@
 #pragma once
 
 #include "esphome/core/component.h"
+#include "esphome/components/button/button.h"
 #include "esphome/components/i2c/i2c.h"
 #include "esphome/components/text_sensor/text_sensor.h"
 #include "esphome/core/automation.h"
+#include "esphome/core/helpers.h"
 #include "esphome/core/optional.h"
 
 #include "i2c_data.h"
@@ -149,6 +151,15 @@ class FaderBuddy : public PollingComponent, public i2c::I2CDevice {
 };
 
 // Action classes for automation
+// A press runs the same thing as the fader_buddy.run_self_calibration action.
+// The fader sweeps to both ends and characterises its motor, which takes a few
+// seconds and moves the carriage - hence entity_category "config", so Home
+// Assistant files it with the device's settings rather than its controls.
+class SelfCalibrationButton : public button::Button, public Parented<FaderBuddy> {
+ protected:
+  void press_action() override { this->parent_->run_self_calibration(); }
+};
+
 template<typename... Ts> class SetActiveLayerAction : public Action<Ts...> {
  public:
   SetActiveLayerAction(FaderBuddy *parent) : parent_(parent) {}

--- a/esphome/components/fader_buddy/i2c_data.h
+++ b/esphome/components/fader_buddy/i2c_data.h
@@ -58,6 +58,12 @@
  * -----|---------------------|---------|------|------------
  * 0x0F | LAYER_HAPTIC_CONFIG | R/W     | -    | Layer haptic config (layer-addressed, u16)
  * -----|---------------------|---------|------|------------
+ * 0x10 | DEBUG_DRIVE         | W       | u8[2]| Open-loop motor drive (DEBUG_DRIVE builds only)
+ * -----|---------------------|---------|------|------------
+ * 0x11 | DEBUG_STATUS        | R       |u8[16]| Control-loop internals (DEBUG_DRIVE builds only)
+ * -----|---------------------|---------|------|------------
+ * 0x12 | DEBUG_GAINS         | W       | u8[3]| Runtime gain override (DEBUG_DRIVE builds only)
+ * -----|---------------------|---------|------|------------
  *
  * Protocol:
  * - Simple registers:
@@ -91,6 +97,61 @@
 #define REG_ACTIVE_LAYER 0x0D  // Active layer index (R/W, u8)
 #define REG_LAYER_TARGET 0x0E  // Layer restore position (layer-addressed, R/W, u8)
 #define REG_LAYER_HAPTIC_CONFIG 0x0F  // Layer haptic config (layer-addressed, R/W, u16)
+#define REG_DEBUG_DRIVE 0x10  // Open-loop motor drive (W, [flags, duty]); DEBUG_DRIVE builds only
+
+/*
+ * REG_DEBUG_DRIVE (0x10) - write-only, present only in DEBUG_DRIVE builds.
+ *
+ * Write [0x10, flags, duty] to command the H-bridge directly, bypassing the
+ * control loop, for system identification. Writing flags = 0xFF exits open-loop
+ * mode. The firmware coasts the motor if a command is not refreshed within
+ * 400 ms, or if the fader nears a travel limit.
+ */
+#define DEBUG_DRIVE_FLAGS_EXIT (0xFF)
+
+// Direction: 2 bits at position 0
+#define DEBUG_DRIVE_DIR_bp (0)
+#define DEBUG_DRIVE_DIR_bm (0x03 << DEBUG_DRIVE_DIR_bp)
+#define DEBUG_DRIVE_DIR_COAST (0)
+#define DEBUG_DRIVE_DIR_A     (1)  // Toward the motor end (rising ADC)
+#define DEBUG_DRIVE_DIR_B     (2)  // Toward the low end (falling ADC)
+#define DEBUG_DRIVE_DIR_BRAKE (3)  // Both low sides on (dynamic braking)
+
+// Decay mode: 1 bit at position 2 (0 = fast/coast, 1 = slow/brake)
+#define DEBUG_DRIVE_SLOW_DECAY_bp (2)
+#define DEBUG_DRIVE_SLOW_DECAY_bm (1 << DEBUG_DRIVE_SLOW_DECAY_bp)
+
+// PWM prescaler select: 2 bits at position 4
+// 0 = DIV4 (19.6 kHz), 1 = DIV256 (306 Hz), 2 = DIV2 (39.2 kHz), 3 = DIV8 (9.8 kHz)
+#define DEBUG_DRIVE_CLK_bp (4)
+#define DEBUG_DRIVE_CLK_bm (0x03 << DEBUG_DRIVE_CLK_bp)
+
+/*
+ * REG_DEBUG_STATUS (0x11) - read-only, DEBUG_DRIVE builds only.
+ * 16 bytes, big-endian: calib_min u16, calib_max u16, target_adc i16,
+ * drive i16, velocity i16 (ADC counts/sec), error_x8 i16 (error * 8),
+ * loop_hz u16, tick_hz u16.
+ */
+#define REG_DEBUG_STATUS 0x11
+
+/*
+ * REG_DEBUG_GAINS (0x12) - write-only, DEBUG_DRIVE builds only.
+ * Write [0x12, index, value_hi, value_lo] to override one control-loop gain at
+ * runtime, so tuning doesn't need a reflash per trial. Values are fixed point:
+ * KP and KD are scaled by 1000, the rest are integers.
+ */
+#define REG_DEBUG_GAINS 0x12
+#define DEBUG_GAIN_KP          (0)  // duty per ADC count, x1000
+#define DEBUG_GAIN_KD          (1)  // duty per (ADC count/sec), x1000
+#define DEBUG_GAIN_FF_RISING   (2)  // duty
+#define DEBUG_GAIN_FF_FALLING  (3)  // duty
+#define DEBUG_GAIN_DEADBAND    (4)  // ADC counts, x1000
+#define DEBUG_GAIN_TICK_US     (5)  // control tick period, microseconds
+#define DEBUG_GAIN_RAMP_RATE   (6)  // stiction ramp rate, duty per second
+#define DEBUG_GAIN_TAKEUP      (7)  // backlash take-up duty ceiling (0 = disabled)
+#define DEBUG_GAIN_CALIB_MIN   (8)  // override calib_min (RAM only, not saved)
+#define DEBUG_GAIN_CALIB_MAX   (9)  // override calib_max (RAM only, not saved)
+
 
 enum Mode : uint8_t {
   MODE_REMOTE_MOVEMENT_IN_PROGRESS = 0,

--- a/esphome/components/fader_buddy/i2c_data.h
+++ b/esphome/components/fader_buddy/i2c_data.h
@@ -54,7 +54,7 @@
  * -----|---------------------|---------|------|------------
  * 0x0D | ACTIVE_LAYER        | R/W     | u8   | Active layer index (0-7)
  * -----|---------------------|---------|------|------------
- * 0x0E | LAYER_TARGET        | R/W     | -    | Layer restore position (layer-addressed, see below)
+ * 0x0E | LAYER_TARGET        | R/W     | -    | Layer restore position + optional move time (see below)
  * -----|---------------------|---------|------|------------
  * 0x0F | LAYER_HAPTIC_CONFIG | R/W     | -    | Layer haptic config (layer-addressed, u16)
  * -----|---------------------|---------|------|------------
@@ -72,6 +72,12 @@
  * - Layer-addressed registers (0x0E, 0x0F):
  *   - Read:  Write [register, layer], then read N bytes for that layer
  *   - Write: Write [register, layer, ...data] to write to specific layer
+ *
+ * LAYER_TARGET (0x0E) accepts an OPTIONAL trailing speed-limit byte:
+ *   [0x0E, layer, position]           - move at full speed (unchanged behaviour)
+ *   [0x0E, layer, position, move_time] - move no faster than this
+ * Three-byte writes behave exactly as before, so this is backwards compatible
+ * and does not change the protocol version. See LAYER_MOVE_TIME below.
  * - All multi-byte values are big-endian (MSB first)
  *
  * v5 Breaking Changes from v4:
@@ -97,6 +103,29 @@
 #define REG_ACTIVE_LAYER 0x0D  // Active layer index (R/W, u8)
 #define REG_LAYER_TARGET 0x0E  // Layer restore position (layer-addressed, R/W, u8)
 #define REG_LAYER_HAPTIC_CONFIG 0x0F  // Layer haptic config (layer-addressed, R/W, u16)
+/*
+ * Optional move-time limit for LAYER_TARGET writes.
+ *
+ * The byte is the time a FULL-SCALE move (0 -> 255) should take, in units of
+ * 10 ms. 0 means unlimited (the default, and what a 3-byte write leaves in
+ * place). So 100 = "one second for full travel"; range 10 ms .. 2550 ms.
+ *
+ * It is a velocity cap, not a move scheduler: a shorter move takes
+ * proportionally less time rather than being stretched to fill the duration.
+ *
+ * This is a LIMIT and not a precise speed. It is realised through a
+ * friction-dependent plant, so actual timing varies with the fader - expect
+ * within roughly 15% for full-travel times up to ~800 ms, and about 7%
+ * difference between the two directions of travel.
+ *
+ * The mechanism cannot move smoothly below roughly 200 position counts/sec, so
+ * requests slower than about 1.2 s of full travel are clamped rather than
+ * honoured; below that speed the motor creeps in stick-slip steps instead of
+ * moving continuously.
+ */
+#define LAYER_MOVE_TIME_UNLIMITED (0)
+#define LAYER_MOVE_TIME_MS_PER_UNIT (10)
+
 #define REG_DEBUG_DRIVE 0x10  // Open-loop motor drive (W, [flags, duty]); DEBUG_DRIVE builds only
 
 /*
@@ -149,6 +178,7 @@
 #define DEBUG_GAIN_TICK_US     (5)  // control tick period, microseconds
 #define DEBUG_GAIN_RAMP_RATE   (6)  // stiction ramp rate, duty per second
 #define DEBUG_GAIN_TAKEUP      (7)  // backlash take-up duty ceiling (0 = disabled)
+#define DEBUG_GAIN_TAKEUP_RAMP (10) // take-up ceiling ramp rate, duty per second
 #define DEBUG_GAIN_CALIB_MIN   (8)  // override calib_min (RAM only, not saved)
 #define DEBUG_GAIN_CALIB_MAX   (9)  // override calib_max (RAM only, not saved)
 

--- a/esphome/components/fader_buddy/i2c_data.h
+++ b/esphome/components/fader_buddy/i2c_data.h
@@ -278,7 +278,6 @@
 #define DEBUG_GAIN_CALIB_MIN   (8)  // override calib_min (RAM only, not saved)
 #define DEBUG_GAIN_CALIB_MAX   (9)  // override calib_max (RAM only, not saved)
 
-
 enum Mode : uint8_t {
   MODE_REMOTE_MOVEMENT_IN_PROGRESS = 0,
   MODE_INPUT_ACTIVE                = 1,
@@ -301,22 +300,22 @@ enum HapticMode : uint8_t {
 // Touch: 1 bit at position 0
 #define STATE_TOUCH_bp (0)
 #define STATE_TOUCH_bs (1)
-#define STATE_TOUCH_bm (((1U << STATE_TOUCH_bs) - 1) << STATE_TOUCH_bp)
+#define STATE_TOUCH_bm (((1UL << STATE_TOUCH_bs) - 1) << STATE_TOUCH_bp)
 
 // Mode: 3 bits at position 1
 #define STATE_MODE_bp (1)
 #define STATE_MODE_bs (3)
-#define STATE_MODE_bm (((1U << STATE_MODE_bs) - 1) << STATE_MODE_bp)
+#define STATE_MODE_bm (((1UL << STATE_MODE_bs) - 1) << STATE_MODE_bp)
 
 // Active layer: 3 bits at position 4 (replaces haptic_config_nonce in v5)
 #define STATE_ACTIVE_LAYER_bp      (4)
 #define STATE_ACTIVE_LAYER_bs      (3)
-#define STATE_ACTIVE_LAYER_bm      (((1U << STATE_ACTIVE_LAYER_bs) - 1) << STATE_ACTIVE_LAYER_bp)
+#define STATE_ACTIVE_LAYER_bm      (((1UL << STATE_ACTIVE_LAYER_bs) - 1) << STATE_ACTIVE_LAYER_bp)
 
 // Position: 8 bits at position 7
 #define STATE_POSITION_bp            (7)
 #define STATE_POSITION_bs            (8)
-#define STATE_POSITION_bm            (((1U << STATE_POSITION_bs) - 1) << STATE_POSITION_bp)
+#define STATE_POSITION_bm            (((1UL << STATE_POSITION_bs) - 1) << STATE_POSITION_bp)
 
 // Position nonce: 2 bits at position 15
 #define STATE_POSITION_NONCE_bp            (15)

--- a/esphome/components/fader_buddy/i2c_data.h
+++ b/esphome/components/fader_buddy/i2c_data.h
@@ -54,15 +54,17 @@
  * -----|---------------------|---------|------|------------
  * 0x0D | ACTIVE_LAYER        | R/W     | u8   | Active layer index (0-7)
  * -----|---------------------|---------|------|------------
- * 0x0E | LAYER_TARGET        | R/W     | -    | Layer restore position + optional move time (see below)
+ * 0x0E | LAYER_TARGET        | R/W     | -    | Layer restore position + optional speed (see below)
  * -----|---------------------|---------|------|------------
  * 0x0F | LAYER_HAPTIC_CONFIG | R/W     | -    | Layer haptic config (layer-addressed, u16)
  * -----|---------------------|---------|------|------------
- * 0x10 | DEBUG_DRIVE         | W       | u8[2]| Open-loop motor drive (DEBUG_DRIVE builds only)
+ * 0x10 | ...                 |         |      | (free - next production register goes here)
  * -----|---------------------|---------|------|------------
- * 0x11 | DEBUG_STATUS        | R       |u8[16]| Control-loop internals (DEBUG_DRIVE builds only)
+ * 0xF0 | DEBUG_DRIVE         | W       | u8[2]| Open-loop motor drive (DEBUG_DRIVE builds only)
  * -----|---------------------|---------|------|------------
- * 0x12 | DEBUG_GAINS         | W       | u8[3]| Runtime gain override (DEBUG_DRIVE builds only)
+ * 0xF1 | DEBUG_STATUS        | R       |u8[16]| Control-loop internals (DEBUG_DRIVE builds only)
+ * -----|---------------------|---------|------|------------
+ * 0xF2 | DEBUG_GAINS         | W       | u8[3]| Runtime gain override (DEBUG_DRIVE builds only)
  * -----|---------------------|---------|------|------------
  *
  * Protocol:
@@ -73,11 +75,11 @@
  *   - Read:  Write [register, layer], then read N bytes for that layer
  *   - Write: Write [register, layer, ...data] to write to specific layer
  *
- * LAYER_TARGET (0x0E) accepts an OPTIONAL trailing speed-limit byte:
- *   [0x0E, layer, position]           - move at full speed (unchanged behaviour)
- *   [0x0E, layer, position, move_time] - move no faster than this
+ * LAYER_TARGET (0x0E) accepts an OPTIONAL trailing speed byte:
+ *   [0x0E, layer, position]        - move at full speed (unchanged behaviour)
+ *   [0x0E, layer, position, speed] - move no faster than this
  * Three-byte writes behave exactly as before, so this is backwards compatible
- * and does not change the protocol version. See LAYER_MOVE_TIME below.
+ * and does not change the protocol version. See LAYER_SPEED below.
  * - All multi-byte values are big-endian (MSB first)
  *
  * v5 Breaking Changes from v4:
@@ -104,34 +106,44 @@
 #define REG_LAYER_TARGET 0x0E  // Layer restore position (layer-addressed, R/W, u8)
 #define REG_LAYER_HAPTIC_CONFIG 0x0F  // Layer haptic config (layer-addressed, R/W, u16)
 /*
- * Optional move-time limit for LAYER_TARGET writes.
+ * Optional speed byte for LAYER_TARGET writes.
  *
- * The byte is the time a FULL-SCALE move (0 -> 255) should take, in units of
- * 10 ms. 0 means unlimited (the default, and what a 3-byte write leaves in
- * place). So 100 = "one second for full travel"; range 10 ms .. 2550 ms.
+ * A unitless 0-255 speed: 255 is full speed (no limit, the default), and 0 is
+ * the slowest the mechanism moves smoothly. The scale is linear in velocity
+ * and its ends are the ends of the validated range - roughly 700 ms of full
+ * travel at 0, down to 250 ms at 254 - so every value is usable and there are
+ * no awkward bounds for a host to know about.
  *
  * It is a velocity cap, not a move scheduler: a shorter move takes
- * proportionally less time rather than being stretched to fill the duration.
+ * proportionally less time rather than being stretched to fill a duration.
  *
  * This is a LIMIT and not a precise speed. It is realised through a
  * friction-dependent plant, so actual timing varies with the fader - expect
- * within roughly 15% for full-travel times up to ~800 ms, and about 7%
- * difference between the two directions of travel.
+ * within roughly 15% of the nominal speed, and about 7% difference between the
+ * two directions of travel. Speeds below the bottom of the scale are not
+ * reachable at all: the motor cannot sustain continuous rotation there and
+ * creeps in stick-slip steps instead, which is why 0 stops where it does.
  *
- * The mechanism cannot move smoothly below roughly 200 position counts/sec, so
- * requests slower than about 1.2 s of full travel are clamped rather than
- * honoured; below that speed the motor creeps in stick-slip steps instead of
- * moving continuously.
+ * A 3-byte write leaves the layer's stored speed alone, and layers power up at
+ * LAYER_SPEED_FULL, so a host that never sends the byte moves at full speed.
+ * Send full-speed moves as 3-byte writes: firmware predating this byte ignores
+ * a 4-byte write entirely rather than moving.
  */
-#define LAYER_MOVE_TIME_UNLIMITED (0)
-#define LAYER_MOVE_TIME_MS_PER_UNIT (10)
-
-#define REG_DEBUG_DRIVE 0x10  // Open-loop motor drive (W, [flags, duty]); DEBUG_DRIVE builds only
+#define LAYER_SPEED_SLOWEST (0)
+#define LAYER_SPEED_FULL (255)
 
 /*
- * REG_DEBUG_DRIVE (0x10) - write-only, present only in DEBUG_DRIVE builds.
+ * Debug registers live at the top of the address space, not immediately after
+ * the production registers, so that adding a real register never has to step
+ * over them or leave a hole where they used to be. They are compiled out of
+ * production builds entirely, so nothing on a shipped board answers here.
+ */
+#define REG_DEBUG_DRIVE 0xF0  // Open-loop motor drive (W, [flags, duty]); DEBUG_DRIVE builds only
+
+/*
+ * REG_DEBUG_DRIVE (0xF0) - write-only, present only in DEBUG_DRIVE builds.
  *
- * Write [0x10, flags, duty] to command the H-bridge directly, bypassing the
+ * Write [0xF0, flags, duty] to command the H-bridge directly, bypassing the
  * control loop, for system identification. Writing flags = 0xFF exits open-loop
  * mode. The firmware coasts the motor if a command is not refreshed within
  * 400 ms, or if the fader nears a travel limit.
@@ -156,20 +168,20 @@
 #define DEBUG_DRIVE_CLK_bm (0x03 << DEBUG_DRIVE_CLK_bp)
 
 /*
- * REG_DEBUG_STATUS (0x11) - read-only, DEBUG_DRIVE builds only.
+ * REG_DEBUG_STATUS (0xF1) - read-only, DEBUG_DRIVE builds only.
  * 16 bytes, big-endian: calib_min u16, calib_max u16, target_adc i16,
  * drive i16, velocity i16 (ADC counts/sec), error_x8 i16 (error * 8),
  * loop_hz u16, tick_hz u16.
  */
-#define REG_DEBUG_STATUS 0x11
+#define REG_DEBUG_STATUS 0xF1
 
 /*
- * REG_DEBUG_GAINS (0x12) - write-only, DEBUG_DRIVE builds only.
- * Write [0x12, index, value_hi, value_lo] to override one control-loop gain at
+ * REG_DEBUG_GAINS (0xF2) - write-only, DEBUG_DRIVE builds only.
+ * Write [0xF2, index, value_hi, value_lo] to override one control-loop gain at
  * runtime, so tuning doesn't need a reflash per trial. Values are fixed point:
  * KP and KD are scaled by 1000, the rest are integers.
  */
-#define REG_DEBUG_GAINS 0x12
+#define REG_DEBUG_GAINS 0xF2
 #define DEBUG_GAIN_KP          (0)  // duty per ADC count, x1000
 #define DEBUG_GAIN_KD          (1)  // duty per (ADC count/sec), x1000
 #define DEBUG_GAIN_FF_RISING   (2)  // duty

--- a/esphome/components/fader_buddy/i2c_data.h
+++ b/esphome/components/fader_buddy/i2c_data.h
@@ -208,8 +208,11 @@
  *
  * A 3-byte write leaves the layer's stored speed alone, and layers power up at
  * LAYER_SPEED_FULL, so a host that never sends the byte moves at full speed.
- * Send full-speed moves as 3-byte writes: firmware predating this byte ignores
- * a 4-byte write entirely rather than moving.
+ *
+ * A host that DOES use the byte should send it on every move, LAYER_SPEED_FULL
+ * included: dropping back to a 3-byte write re-applies whatever limit the layer
+ * last stored, rather than moving at full speed. Send 3 bytes only when talking
+ * to firmware that predates the byte, which ignores a 4-byte write entirely.
  */
 #define LAYER_SPEED_SLOWEST (0)
 #define LAYER_SPEED_FULL (255)

--- a/esphome/components/fader_buddy/i2c_data.h
+++ b/esphome/components/fader_buddy/i2c_data.h
@@ -18,6 +18,40 @@
 #include <stdint.h>
 
 #define I2C_PROTOCOL_VERSION (5)  // v5: Layer management in firmware, 16-bit haptic config
+// The protocol version covers the WIRE FORMAT of the registers below, and is
+// deliberately not bumped for additive changes that older hosts can ignore -
+// the LAYER_TARGET speed byte being the case in point. Feature-detect on
+// FW_VERSION instead; hosts that hard-fail on an unexpected protocol version
+// would otherwise be bricked by a bump they didn't need to care about.
+
+/*
+ * Application firmware version, as a packed u16: (major << 8) | minor.
+ * Reported at REG_FW_VERSION, and MONOTONICALLY INCREASING, so a host can both
+ * feature-gate on it and compare it against a packaged image to decide whether
+ * an update is needed. Bump the minor on every released build that changes
+ * observable behaviour.
+ *
+ * Two values are reserved and never reported by a real build:
+ *   0x0000 - unused
+ *   0xFFFF - what an I2C read returns from firmware that has no FW_VERSION
+ *            register at all: the peripheral stops driving SDA for an unknown
+ *            register and the bus pulls high. Firmware that old is treated as
+ *            version 1.0 - the last unversioned release.
+ *
+ * Overridable via build flag (-DFW_VERSION=N) so one-off builds can stamp a
+ * different version without touching this default.
+ */
+#define FW_VERSION_MAJOR (1)
+#define FW_VERSION_MINOR (1)
+#ifndef FW_VERSION
+#define FW_VERSION ((FW_VERSION_MAJOR << 8) | FW_VERSION_MINOR)
+#endif
+#define FW_VERSION_NONE (0xFFFF)  // read back from firmware predating the register
+
+// Minimum firmware version that honours the LAYER_TARGET speed byte. Older
+// firmware ignores a 4-byte write completely, so a host MUST check this before
+// sending one rather than letting the move be silently dropped.
+#define FW_VERSION_MOVE_SPEED (0x0101)  // 1.1
 
 
 /*
@@ -58,7 +92,11 @@
  * -----|---------------------|---------|------|------------
  * 0x0F | LAYER_HAPTIC_CONFIG | R/W     | -    | Layer haptic config (layer-addressed, u16)
  * -----|---------------------|---------|------|------------
- * 0x10 | ...                 |         |      | (free - next production register goes here)
+ * 0x10 | (reserved)          |         |      | Reserved for ENTER_BOOTLOADER (I2C bootloader work)
+ * -----|---------------------|---------|------|------------
+ * 0x11 | FW_VERSION          | R       | u16  | Application firmware version (see FW_VERSION)
+ * -----|---------------------|---------|------|------------
+ * 0x12 | ...                 |         |      | (free - next production register goes here)
  * -----|---------------------|---------|------|------------
  * 0xF0 | DEBUG_DRIVE         | W       | u8[2]| Open-loop motor drive (DEBUG_DRIVE builds only)
  * -----|---------------------|---------|------|------------
@@ -105,6 +143,8 @@
 #define REG_ACTIVE_LAYER 0x0D  // Active layer index (R/W, u8)
 #define REG_LAYER_TARGET 0x0E  // Layer restore position (layer-addressed, R/W, u8)
 #define REG_LAYER_HAPTIC_CONFIG 0x0F  // Layer haptic config (layer-addressed, R/W, u16)
+// 0x10 reserved for REG_ENTER_BOOTLOADER (see the I2C bootloader work)
+#define REG_FW_VERSION 0x11  // Application firmware version (R, u16 big-endian, see FW_VERSION)
 /*
  * Optional speed byte for LAYER_TARGET writes.
  *

--- a/esphome/components/fader_buddy/i2c_data.h
+++ b/esphome/components/fader_buddy/i2c_data.h
@@ -42,7 +42,7 @@
  * different version without touching this default.
  */
 #define FW_VERSION_MAJOR (1)
-#define FW_VERSION_MINOR (1)
+#define FW_VERSION_MINOR (2)
 #ifndef FW_VERSION
 #define FW_VERSION ((FW_VERSION_MAJOR << 8) | FW_VERSION_MINOR)
 #endif
@@ -52,6 +52,10 @@
 // firmware ignores a 4-byte write completely, so a host MUST check this before
 // sending one rather than letting the move be silently dropped.
 #define FW_VERSION_MOVE_SPEED (0x0101)  // 1.1
+
+// Minimum firmware version that measures motor characteristics during
+// self-calibration and reports them at REG_MOTOR_CAL.
+#define FW_VERSION_MOTOR_CAL (0x0102)  // 1.2
 
 
 /*
@@ -96,7 +100,9 @@
  * -----|---------------------|---------|------|------------
  * 0x11 | FW_VERSION          | R       | u16  | Application firmware version (see FW_VERSION)
  * -----|---------------------|---------|------|------------
- * 0x12 | ...                 |         |      | (free - next production register goes here)
+ * 0x12 | MOTOR_CAL           | R       |u8[12]| Measured motor characteristics (see below)
+ * -----|---------------------|---------|------|------------
+ * 0x13 | ...                 |         |      | (free - next production register goes here)
  * -----|---------------------|---------|------|------------
  * 0xF0 | DEBUG_DRIVE         | W       | u8[2]| Open-loop motor drive (DEBUG_DRIVE builds only)
  * -----|---------------------|---------|------|------------
@@ -145,6 +151,42 @@
 #define REG_LAYER_HAPTIC_CONFIG 0x0F  // Layer haptic config (layer-addressed, R/W, u16)
 // 0x10 reserved for REG_ENTER_BOOTLOADER (see the I2C bootloader work)
 #define REG_FW_VERSION 0x11  // Application firmware version (R, u16 big-endian, see FW_VERSION)
+#define REG_MOTOR_CAL 0x12  // Measured motor characteristics (R, 12 bytes, see below)
+
+/*
+ * REG_MOTOR_CAL (0x12) - read-only, 12 bytes.
+ *
+ * What self-calibration measured about THIS motor, and the feedforward it
+ * derived from it. Purely diagnostic: the firmware needs no host involvement
+ * to use these, and a host that ignores the register loses nothing.
+ *
+ * The control law is written against three per-unit plant parameters, because
+ * the same duty means different things on different faders (see
+ * firmware/ABOUT_MOTOR_CONTROL.md):
+ *
+ *   breakaway  duty at which the carriage first moves at all
+ *   k          ADC counts/sec of cruise per duty count above breakaway
+ *   v_jump     the speed motion starts at once breakaway is crossed - the
+ *              Stribeck jump, which sets the floor on the on-target deadband
+ *
+ *   byte  0    valid          1 = measured, 0 = using compiled-in defaults
+ *   byte  1    breakaway_rising   duty
+ *   byte  2    breakaway_falling  duty
+ *   byte  3    k_rising           ADC counts/sec per duty
+ *   byte  4    k_falling          ADC counts/sec per duty
+ *   bytes 5-6  v_jump_rising      ADC counts/sec, big-endian u16
+ *   bytes 7-8  v_jump_falling     ADC counts/sec, big-endian u16
+ *   bytes 9-10 vel_min            slowest velocity reference the control law
+ *                                 will ask for, ADC counts/sec, big-endian u16
+ *   byte 11    deadband           on-target window, ADC counts
+ *
+ * breakaway and k feed the feedforward (breakaway + v_ref/k) and the velocity
+ * loop gain (scaled by 1/k); v_jump sets vel_min and the deadband floor.
+ *
+ * With valid = 0 the measurement never ran, or ran and produced values outside
+ * the plausible range; bytes 1-8 are then zero and 9-11 report the compiled-in
+ * defaults actually in use. Trigger a measurement with REG_SELF_CAL.
+ */
 /*
  * Optional speed byte for LAYER_TARGET writes.
  *
@@ -222,10 +264,12 @@
  * KP and KD are scaled by 1000, the rest are integers.
  */
 #define REG_DEBUG_GAINS 0xF2
-#define DEBUG_GAIN_KP          (0)  // duty per ADC count, x1000
-#define DEBUG_GAIN_KD          (1)  // duty per (ADC count/sec), x1000
-#define DEBUG_GAIN_FF_RISING   (2)  // duty
-#define DEBUG_GAIN_FF_FALLING  (3)  // duty
+#define DEBUG_GAIN_VREF_SLOPE  (0)  // velocity reference per ADC count of error, x1000
+#define DEBUG_GAIN_KV          (1)  // duty per (ADC count/sec) of velocity error, x1000
+#define DEBUG_GAIN_BD_RISING   (2)  // assumed breakaway duty, rising
+#define DEBUG_GAIN_BD_FALLING  (3)  // assumed breakaway duty, falling
+#define DEBUG_GAIN_K           (11) // assumed ADC counts/sec per duty, both directions
+#define DEBUG_GAIN_VEL_MIN     (12) // velocity reference floor, ADC counts/sec
 #define DEBUG_GAIN_DEADBAND    (4)  // ADC counts, x1000
 #define DEBUG_GAIN_TICK_US     (5)  // control tick period, microseconds
 #define DEBUG_GAIN_RAMP_RATE   (6)  // stiction ramp rate, duty per second

--- a/esphome/components/fader_buddy/text_sensor.py
+++ b/esphome/components/fader_buddy/text_sensor.py
@@ -11,27 +11,60 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""DEPRECATED: `text_sensor: platform: fader_buddy`.
+
+The hub creates its own diagnostic text sensors now, so this platform exists
+only to keep existing configs working. It will be removed in component 0.5.0.
+
+To migrate, delete the whole `text_sensor:` entry. The hub already provides a
+serial number sensor; move any `name:`/`id:`/`icon:` onto the hub's own
+`serial_number:` key if you were overriding them:
+
+    fader_buddy:
+      - id: my_fader
+        serial_number:
+          name: "My Fader Serial"
+"""
+
+import logging
+
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import text_sensor
 
-from . import CONF_FADER_BUDDY_ID, FaderBuddy
+from . import CONF_FADER_BUDDY_ID, CONF_SERIAL_NUMBER, FaderBuddy
 
 DEPENDENCIES = ["fader_buddy"]
 
-CONF_SERIAL_NUMBER = "serial_number"
+_LOGGER = logging.getLogger(__name__)
 
-CONFIG_SCHEMA = cv.Schema(
-    {
-        cv.GenerateID(CONF_FADER_BUDDY_ID): cv.use_id(FaderBuddy),
-        cv.Optional(CONF_SERIAL_NUMBER): text_sensor.text_sensor_schema(
-            entity_category="diagnostic",
-        ),
-    }
+
+def _warn_deprecated(config):
+    _LOGGER.warning(
+        "`text_sensor: platform: fader_buddy` is deprecated and will be removed in "
+        "fader_buddy 0.5.0. The hub creates its diagnostic text sensors itself now - "
+        "delete this text_sensor block, and if you were overriding the name or icon, "
+        "move that onto the hub's own `serial_number:` key instead."
+    )
+    return config
+
+
+CONFIG_SCHEMA = cv.All(
+    cv.Schema(
+        {
+            cv.GenerateID(CONF_FADER_BUDDY_ID): cv.use_id(FaderBuddy),
+            cv.Optional(CONF_SERIAL_NUMBER): text_sensor.text_sensor_schema(
+                entity_category="diagnostic",
+            ),
+        }
+    ),
+    _warn_deprecated,
 )
 
 
 async def to_code(config):
+    # The hub skips creating its own sensor for anything claimed here (see
+    # _claimed_by_legacy_platform in __init__.py), so this stays the only one.
     parent = await cg.get_variable(config[CONF_FADER_BUDDY_ID])
 
     if CONF_SERIAL_NUMBER in config:

--- a/firmware/ABOUT_MOTOR_CONTROL.md
+++ b/firmware/ABOUT_MOTOR_CONTROL.md
@@ -1,0 +1,279 @@
+# About: motor control and closed-loop tuning
+
+Notes for whoever next touches the movement code in `src/main.cpp`. Covers the
+plant model, why the control law is shaped the way it is, what each constant
+does, and how to re-measure everything on hardware.
+
+## Units
+
+Two different position scales appear in the code and in measurements:
+
+- **ADC counts** (0-1023). What the firmware works in: `input_ewma`,
+  `input_calib_min/max`, `target_adc`, all `MOVE_*` gains.
+- **raw** (0-2046). What the `STATE` register reports, because ADC1 runs with
+  2x accumulation. `raw = 2 * ADC`.
+
+Full travel is about 1956 raw over 60 mm, so **1 mm is about 33 raw / 16 ADC counts**.
+
+"Duty" always means the 0-254 value handed to `motor_set()`, matching the TCA0
+split-mode period.
+
+## The plant
+
+Measured on a jig fader. Numbers vary between units; the shapes do not.
+
+**It is a velocity source with a friction deadband, not a force source.**
+Below a breakaway duty nothing moves at all. Above it, speed is roughly
+proportional to duty. There is no useful "push gently" region: at breakaway the
+speed jumps discontinuously to ~900 raw/s (Stribeck effect). This single fact
+drives almost every design decision below.
+
+**Breakaway duty depends strongly on PWM decay mode, not on frequency:**
+
+| drive scheme            | dir A (rising ADC) | dir B (falling) |
+|-------------------------|--------------------|-----------------|
+| fast decay @ 306 Hz     | ~55                | ~75             |
+| fast decay @ 19.6 kHz   | ~190               | ~200            |
+| slow decay @ 19.6 kHz   | ~70                | ~90             |
+| slow decay @ 39.2 kHz   | ~68                | ~88             |
+
+Direction asymmetry (~20 duty counts) is consistent and real; the two
+directions get separate feedforward constants.
+
+**Velocity above breakaway** rises ~58 raw/s per duty count going up, ~94 going
+down. Full duty is ~16000 raw/s (~490 mm/s).
+
+**Coast-down is first order with tau ~5 ms.** Stopping distance after drive is
+cut is about `v * 6 ms`: 7 raw from 2300 raw/s, 80 raw from 12000 raw/s.
+Braking (both low sides on) only shortens this by ~25% - the mechanism is
+already heavily friction-damped, so **braking is not the anti-overshoot lever**.
+Cutting drive early is.
+
+## Why slow decay
+
+The DRV8837 takes IN1/IN2 as 1/0 forward, 0/1 reverse, 0/0 coast, 1/1 brake.
+
+- **Fast decay** (what the code used to do): PWM one pin, hold the other low, so
+  each cycle alternates drive and coast. Winding current decays through the body
+  diodes every cycle. At a high carrier the average current ends up far below
+  what the duty implies, so low-duty torque collapses - hence the 190 breakaway
+  in the table above.
+- **Slow decay** (what `motor_set(..., slow_decay=true, ...)` does): hold the
+  leading pin high from PORT, PWM the trailing pin between drive and brake, so
+  its high fraction is the inverse duty. Current keeps circulating through the
+  bridge, average current tracks duty, and low-duty torque survives.
+
+This is why movement no longer drops the carrier to 306 Hz. That switch existed
+purely to buy torque back, and it was the audible buzz. There is now one
+permanently inaudible carrier (19.6 kHz) for everything.
+
+**Haptics deliberately still use fast decay.** `HAPTIC_BASE_PWM` and
+`get_strength_max_pwm()`'s 189 floor were tuned against the fast-decay force
+curve. Switching haptics to slow decay would make them far stronger and change
+the feel. If you ever do switch them, those constants must be retuned together.
+
+## The control law
+
+In `motor_update()`, `MODE_REMOTE_MOVEMENT_IN_PROGRESS`:
+
+```
+error = target_adc - input_ewma
+if |error| <= MOVE_DEADBAND:  brake, and start/continue the settle timer
+else:
+    u  = MOVE_KP * error                      # proportional
+    u -= MOVE_KD * velocity_ewma              # damping
+    u += sign(error) * MOVE_FF_{RISING,FALLING}   # friction feedforward
+    u += sign(error) * stiction_ramp          # stall escape
+    clamp |u| to MOVE_TAKEUP_DUTY while stalled, else MOVE_MAX_DUTY
+```
+
+Four ideas, each solving a specific measured problem:
+
+**Feedforward** supplies the breakaway duty so the P term only has to set speed
+rather than fight stiction. Deliberately set *above* the breakaway measured on
+any single fader, and centred in the range that keeps every move settling - not
+tuned for best accuracy on the reference unit. See "Tuning for hardware
+variance" below; this is the single most important thing to understand before
+changing these numbers.
+
+**Derivative** is what prevents overshoot. Drive falls below breakaway when
+`KP*error ≈ KD*velocity`, i.e. at `v = (KP/KD)*error`. With KP 2.0 and KD 0.04
+that is 50/s, against a coast limit of `1/tau ≈ 200/s`. The controller
+therefore cuts drive about four stopping distances short and coasts in. The old
+code had no D term and a constant `+80` offset, so it drove at full authority
+right up to the deadband and arrived at ~12000 raw/s - which is precisely the
+58-80 raw overshoot it used to show.
+
+**Stiction ramp** fixes a genuine failure, not just feel. Because FF sits below
+breakaway, small errors produce `FF + KP*error` below breakaway: the controller
+commands motion it cannot produce, sits stuck outside the deadband, and after
+8 s falls into `MODE_ERROR`. The ramp adds drive at `MOVE_RAMP_RATE` only while
+commanded-but-stalled, capped at `MOVE_RAMP_MAX`, and is dropped the moment the
+carriage moves so it never contributes to overshoot. The cap also means a
+jammed fader cannot wind up to full drive.
+
+**Take-up limit** addresses belt backlash. A direction-reversed move otherwise
+starts at full duty into slack: the rotor free-runs unloaded, then snaps taut
+with an audible click and a jerk. While stalled, drive is capped at
+`MOVE_TAKEUP_DUTY` - enough to cross the slack promptly, gentle on engagement.
+Full authority returns as soon as the carriage moves, costing a few ms.
+
+## Fixed-rate loop and the velocity estimate
+
+The control law runs on a `CONTROL_TICK_US` tick, not once per `loop()`.
+Previously it ran every iteration, so gains and filter constants were per
+*iteration* and drifted with however long touch processing took. `adc_drain()`
+still runs every pass, folding every completed ADC conversion into `input_ewma`
+on the `RESRDY` flag, so the position filter runs at the ADC's own constant rate
+and never re-uses or tears a result.
+
+Velocity is `d(input_ewma)/dt`, smoothed with a fixed time constant
+`VELOCITY_TAU_S`. `input_ewma` is a float fed by a dithered ADC, so its
+differences stay meaningful well below one ADC count - no need for a longer
+baseline. **dt is measured from the previous execution, not the scheduled tick
+time**; using the schedule silently skews the estimate whenever the loop cannot
+keep up.
+
+At 2 kHz the main loop still runs 6-8 kHz, leaving headroom for `ptc_process`.
+At 250 us the loop saturates (loop rate == tick rate) with no margin; don't.
+
+## Constants and how to change them
+
+| constant | value | effect |
+|---|---|---|
+| `CONTROL_TICK_US` | 500 | 2 kHz. Higher rates gain little; the limit is friction, not sample rate. |
+| `MOVE_KP` | 2.0 | Approach speed. 3.0+ oscillates. |
+| `MOVE_KD` | 0.04 | Damping. Main speed/robustness dial - see below. |
+| `MOVE_FF_RISING/FALLING` | 106 / 124 | Per-direction friction feedforward, centred for hardware variance. Do not lower. |
+| `MOVE_DEADBAND` | 6.0 | On-target window. Has a hard floor - see below. Don't lower it. |
+| `MOVE_STALL_VELOCITY` | 60 | "Not moving" threshold, for ramp and take-up. |
+| `MOVE_RAMP_RATE/MAX` | 250 / 70 | Stall escape strength. |
+| `MOVE_TAKEUP_DUTY` | 95 | Backlash gentleness. 0 disables. |
+| `MOVE_TIMEOUT_TOLERANCE` | 20 | On timeout, error below this goes idle instead of `MODE_ERROR`. |
+
+**The deadband has a floor set by the plant, not by taste.** Nothing moves
+below breakaway, and at breakaway speed jumps straight to ~900 raw/s, so the
+smallest correction the fader can make is that speed times the reaction plus
+stopping time - about 10-16 raw, i.e. 5-8 ADC counts. Set the deadband below
+that floor and a fader whose breakaway does not match the feedforward constants
+will step past the window in both directions indefinitely and trip the movement
+timeout. This was a real field failure: 2.5 worked on the fader the gains were
+tuned against, where fine control was possible, and hung on a different one.
+There is nothing to gain by tightening it either - 6 ADC counts is about 1.5 LSB
+of the 8-bit position the host actually sees.
+
+`MOVE_TIMEOUT_TOLERANCE` is the backstop for the same problem. On movement
+timeout, an error small enough to mean "arrived but hunting" goes quietly idle;
+only a genuinely large error (jam, dead motor, target outside the calibrated
+range) still latches `MODE_ERROR`, which needs a host round-trip to clear.
+
+**KD is the speed/robustness tradeoff.** Lower is faster but rings sooner;
+higher is smoother but slower to settle. Lowering KD is mathematically
+equivalent to adding carriage mass, since both make the carriage coast further,
+so a KD sweep doubles as an inertia sweep. Measured on the jig:
+
+| effective inertia | 1.0x | 1.5x | 2.0x | 3.0x |
+|---|---|---|---|---|
+| reversals over the suite | 0 | 6 | 60 | 145 |
+
+So the tuning tolerates roughly 1.5-2x the *total* moving inertia (carriage +
+belt + reflected rotor inertia) before ringing returns. A plastic knob cap is a
+few grams against that and is not a concern. KD 0.04 rather than 0.03 was chosen
+to widen this margin; the cost is ~40 ms on a full-travel move.
+
+## Tuning for hardware variance
+
+This is an open source project and users run whatever fader they have - newer,
+older, stiffer, looser. **The gains are therefore centred for the widest range
+of hardware that still settles, not for best accuracy on one fader.** A slightly
+missed target is barely noticeable. A fader that takes seconds to settle, or
+times out into `MODE_ERROR`, is a dealbreaker. Optimise in that order.
+
+The parameter that matters is how the feedforward compares to a given unit's
+breakaway duty. Sweeping FF on the reference fader (breakaway 68 rising) shows
+where moves stop settling:
+
+| FF (rising) | 46 | 66 | 86 | 106 | 126 | 146 | 166 |
+|---|---|---|---|---|---|---|---|
+| moves that settled | 3/6 | 6/6 | 6/6 | 6/6 | 6/6 | 6/6 | 4/6 |
+
+The window is roughly **66 to 146**, and it is very lopsided: only about 2 counts
+of room below the reference breakaway, but ~78 above. So FF is set to 106, the
+centre, rather than just under breakaway.
+
+**Why too-low FF is the dangerous direction.** If FF lands below a unit's
+breakaway, small errors cannot produce motion at all. The carriage stalls just
+outside the deadband, the stiction ramp winds up, and when it finally crosses
+breakaway the speed jumps discontinuously to ~900 raw/s - far too fast to stop
+inside the window. It overshoots, the error flips sign, and the cycle repeats
+until the movement timeout. That is what "motor active, oscillating, never
+settles, then error" looks like in the field, and no deadband value fully
+rescues it (tested up to 10 ADC counts).
+
+**Why too-high FF is cheap.** `MOVE_TAKEUP_DUTY` caps drive while the carriage
+is stalled, so an over-high feedforward is simply clamped instead of producing a
+violent escape. Once moving, the D term absorbs the extra.
+
+Measured tolerance at the shipping values, emulated by offsetting FF:
+
+| unit breakaway vs reference | -40 | -30 | -20 | -10 | 0 | +10 | +20 | +30 | +40 |
+|---|---|---|---|---|---|---|---|---|---|
+| moves that settled | 7/7 | 7/7 | 7/7 | 7/7 | 7/7 | 7/7 | 7/7 | 7/7 | 6/7 |
+
+So roughly **-40 to +30 duty counts** of breakaway spread is absorbed, with
+worst-case steady-state error about 5.6 ADC counts (~0.35 mm, under 1.5 LSB of
+the 8-bit position a host sees). The previous "just under breakaway" tuning
+failed already at -10.
+
+With FF centred, the design also stops being sensitive to the other constants:
+every deadband from 3 to 9 and every take-up value from 70 to 150 settles 7/7.
+That insensitivity is the point - if a change makes behaviour depend sharply on
+one constant again, that is a regression even if the reference fader looks good.
+
+If a unit ever falls outside this window, the fix is per-unit calibration rather
+than re-centring the constants: extend self-calibration to ramp duty until
+motion starts in each direction and store the result in EEPROM next to
+`calib_min`/`calib_max`, or have the stiction ramp learn and persist an offset.
+
+## Reproducing the measurements
+
+Two extra build environments exist for this; neither ships.
+
+```bash
+source ~/.platformio/penv/bin/activate
+
+# ATtiny with REG_DEBUG_DRIVE / STATUS / GAINS (repo root)
+pio run -e fader_buddy_lab -t upload
+
+# ESP32 jig as a serial-driven measurement harness, replacing the
+# production test state machine
+cd production_tools/programAndTest && pio run -e lab -t upload
+```
+
+`env:lab` (`src/lab_main.cpp`) gives a line-oriented serial interface at
+921600 baud: `step <from> <to> <ms>` captures a step response at ~3.2 kHz,
+`openloop` and `stopdist` drive the bridge directly for system ID, `dbg` reads
+control-loop internals, and `gain <index> <value>` overrides any tuning constant
+at runtime so a gain sweep does not need a reflash per trial. Gain indices are
+in `i2c_data.h` (`DEBUG_GAIN_*`); KP, KD and deadband are scaled by 1000.
+
+Restore production firmware with `pio run -e fader_buddy -t upload` and
+`pio run -e lilygo-t-display -t upload`.
+
+The debug registers (0x10-0x12) are additive and compiled out unless
+`DEBUG_DRIVE` is defined, so the protocol version is unchanged.
+
+## Measurement gotchas
+
+- **Derive the target from `calib_min`/`calib_max`, not from where the fader
+  settles.** Read them via `REG_DEBUG_STATUS`. Inferring the mapping from
+  settled endpoints bakes in the controller's own error - this produced a
+  phantom 22 raw bias early in tuning.
+- **The `STATE` raw ADC field is noisy while the motor drives.** Excursions of
+  40+ raw appear there that the filtered `pos` field does not show; they are ADC
+  noise, not motion. Median-filter before computing overshoot, and cross-check
+  against `pos`.
+- **Clear `MODE_ERROR` between automated trials.** One latched error otherwise
+  makes every later trial report a frozen fader.
+- Reported `err` from `REG_DEBUG_STATUS` is the same float the controller uses
+  and is the ground truth for steady-state accuracy.

--- a/firmware/ABOUT_MOTOR_CONTROL.md
+++ b/firmware/ABOUT_MOTOR_CONTROL.md
@@ -80,14 +80,22 @@ In `motor_update()`, `MODE_REMOTE_MOVEMENT_IN_PROGRESS`:
 error = target_adc - input_ewma
 if |error| <= MOVE_DEADBAND:  brake, and start/continue the settle timer
 else:
-    u  = MOVE_KP * error                      # proportional
-    u -= MOVE_KD * velocity_ewma              # damping
+    e_ctrl = clamp(error, +/- move_max_error)     # only when speed limited
+    u  = MOVE_KP * e_ctrl                         # proportional
+    u -= MOVE_KD * velocity_ewma                  # damping
     u += sign(error) * MOVE_FF_{RISING,FALLING}   # friction feedforward
-    u += sign(error) * stiction_ramp          # stall escape
-    clamp |u| to MOVE_TAKEUP_DUTY while stalled, else MOVE_MAX_DUTY
+    u += sign(error) * stiction_ramp              # stall escape
+    if speed limited and over speed:              # governor
+        u -= MOVE_VEL_LIMIT_GAIN * overspeed * sign(velocity)
+    drive_ceiling += MOVE_TAKEUP_RAMP_RATE * dt   # opens up from move start
+    clamp |u| to (drive_ceiling + stiction_ramp), capped at MOVE_MAX_DUTY
 ```
 
-Four ideas, each solving a specific measured problem:
+The two speed-limit lines are inactive unless a move time was requested, and
+`drive_ceiling` reaches `MOVE_MAX_DUTY` within about 100 ms, so on a normal move
+this reduces to PD + feedforward + stall escape.
+
+Five ideas, each solving a specific measured problem:
 
 **Feedforward** supplies the breakaway duty so the P term only has to set speed
 rather than fight stiction. Deliberately set *above* the breakaway measured on
@@ -112,11 +120,29 @@ commanded-but-stalled, capped at `MOVE_RAMP_MAX`, and is dropped the moment the
 carriage moves so it never contributes to overshoot. The cap also means a
 jammed fader cannot wind up to full drive.
 
-**Take-up limit** addresses belt backlash. A direction-reversed move otherwise
+**Take-up ceiling** addresses belt backlash. A direction-reversed move otherwise
 starts at full duty into slack: the rotor free-runs unloaded, then snaps taut
-with an audible click and a jerk. While stalled, drive is capped at
-`MOVE_TAKEUP_DUTY` - enough to cross the slack promptly, gentle on engagement.
-Full authority returns as soon as the carriage moves, costing a few ms.
+with an audible click and a jerk. The drive ceiling therefore starts at
+`MOVE_TAKEUP_DUTY` at the beginning of every move and opens up to full over
+time at `MOVE_TAKEUP_RAMP_RATE`.
+
+Two things about this are easy to get wrong, and both were bugs during
+development:
+
+- **It must be time-based, not gated on "are we moving yet".** While crossing
+  the slack the rotor *is* moving, it just isn't loaded, so a velocity-gated
+  ceiling lifts partway through the slack and full duty still lands on
+  engagement. Time is the only available signal that doesn't depend on whether
+  the belt has taken up.
+- **`MOVE_TAKEUP_DUTY` must stay above `MOVE_FF_RISING/FALLING`.** The ceiling
+  exists to stop drive stepping to full duty, not to suppress the feedforward.
+  Set below FF it starves the term that gets the carriage moving: the fader
+  stalls, waits for the stiction ramp, and breaks free abruptly - which hunts
+  *and* makes the click worse. This regressed when FF was re-centred upward and
+  the ceiling was left at its old value.
+
+**Optional speed limit** (see below) is off by default and changes nothing when
+unset.
 
 ## Fixed-rate loop and the velocity estimate
 
@@ -146,9 +172,13 @@ At 250 us the loop saturates (loop rate == tick rate) with no margin; don't.
 | `MOVE_KD` | 0.04 | Damping. Main speed/robustness dial - see below. |
 | `MOVE_FF_RISING/FALLING` | 106 / 124 | Per-direction friction feedforward, centred for hardware variance. Do not lower. |
 | `MOVE_DEADBAND` | 6.0 | On-target window. Has a hard floor - see below. Don't lower it. |
-| `MOVE_STALL_VELOCITY` | 60 | "Not moving" threshold, for ramp and take-up. |
+| `MOVE_STALL_VELOCITY` | 60 | "Not moving" threshold, for the stiction ramp. |
 | `MOVE_RAMP_RATE/MAX` | 250 / 70 | Stall escape strength. |
-| `MOVE_TAKEUP_DUTY` | 95 | Backlash gentleness. 0 disables. |
+| `MOVE_TAKEUP_DUTY` | 130 | Drive ceiling at move start. Must stay above FF. |
+| `MOVE_TAKEUP_RAMP_RATE` | 1200 | Duty/sec the ceiling opens up. Lower = gentler start. |
+| `MOVE_VEL_LIMIT_GAIN` | 0.08 | Speed-limit governor authority. |
+| `MOVE_VELOCITY_PER_ERROR` | 30 | Measured ADC/s of cruise per ADC of error. |
+| `MOVE_VEL_MIN` | 560 | Slowest smoothly sustainable speed (ADC/s). |
 | `MOVE_TIMEOUT_TOLERANCE` | 20 | On timeout, error below this goes idle instead of `MODE_ERROR`. |
 
 **The deadband has a floor set by the plant, not by taste.** Nothing moves
@@ -234,6 +264,48 @@ If a unit ever falls outside this window, the fix is per-unit calibration rather
 than re-centring the constants: extend self-calibration to ramp duty until
 motion starts in each direction and store the result in EEPROM next to
 `calib_min`/`calib_max`, or have the stiction ramp learn and persist an offset.
+
+## Optional speed limiting
+
+`LAYER_TARGET` (0x0E) takes an optional 4th byte capping the speed of the move.
+Three-byte writes behave exactly as before, so this is backwards compatible and
+does not change the protocol version.
+
+The byte is **the time a full-scale (0 -> 255) move should take, in units of
+10 ms**; 0 means unlimited. So 100 means "one second for full travel", and the
+range is 10 ms .. 2550 ms. It is a velocity cap, not a move scheduler: a shorter
+move takes proportionally less time rather than being stretched to fill the
+duration. The conversion is just `velocity = span / time`, with no scaling
+constant to keep in sync.
+
+It takes **two cooperating parts**, and neither works alone - this is the part
+worth understanding before touching it:
+
+- **An error clamp**, so the proportional term cannot saturate. On a large move
+  `KP*error` is around 1300 duty, so the governor below has no authority
+  whatsoever against the 254 ceiling.
+- **A one-sided governor** on measured velocity, so drive can be pulled *below*
+  the feedforward. FF alone commands ~2200 raw counts/sec, so clamping the error
+  can only slow the fader to that floor and never under it.
+
+Measured on the reference fader, requesting a full-scale time and timing a move
+of 67% of full scale:
+
+| requested full-scale | 250 ms | 400 ms | 600 ms | 800 ms | 1200 ms | 2000 ms |
+|---|---|---|---|---|---|---|
+| measured | 193 ms | 261 ms | 356 ms | 444 ms | 584 ms | 759 ms |
+| vs expected | +16% | -2% | -11% | -17% | -27% | -43% |
+
+**Usable range is roughly 250 ms to 700 ms of full-scale time**, tracking within
+about 15%. Beyond that it saturates: there is a hard floor near **1.1 s of
+full travel** (~200 position counts/sec), below which the motor cannot sustain
+continuous rotation and creeps in stick-slip steps rather than moving smoothly.
+Requests slower than that are clamped, not honoured. Slower smooth motion is not
+reachable by tuning - it needs a different drive scheme. Direction asymmetry is
+within about 7%.
+
+Treat this as a *limit*, not a precise speed control - it is realised through
+the friction-dependent plant, so exact velocity varies with the fader.
 
 ## Reproducing the measurements
 

--- a/firmware/ABOUT_MOTOR_CONTROL.md
+++ b/firmware/ABOUT_MOTOR_CONTROL.md
@@ -78,47 +78,76 @@ In `motor_update()`, `MODE_REMOTE_MOVEMENT_IN_PROGRESS`:
 
 ```
 error = target_adc - input_ewma
-if |error| <= MOVE_DEADBAND:  brake, and start/continue the settle timer
+if |error| <= move_deadband:  brake, and start/continue the settle timer
 else:
-    e_ctrl = clamp(error, +/- move_max_error)     # only when speed limited
-    u  = MOVE_KP * e_ctrl                         # proportional
-    u -= MOVE_KD * velocity_ewma                  # damping
-    u += sign(error) * MOVE_FF_{RISING,FALLING}   # friction feedforward
+    v_ref = MOVE_VREF_SLOPE * error               # position loop
+    |v_ref| clamped to the requested speed limit  # if one was requested
+    |v_ref| floored at move_vel_min               # Stribeck floor
+    u  = sign * (breakaway + |v_ref| / k)         # feedforward: plant inverted
+    u += move_kv * (v_ref - velocity_ewma)        # velocity loop
     u += sign(error) * stiction_ramp              # stall escape
-    if speed limited and over speed:              # governor
-        u -= MOVE_VEL_LIMIT_GAIN * overspeed * sign(velocity)
     drive_ceiling += MOVE_TAKEUP_RAMP_RATE * dt   # opens up from move start
     clamp |u| to (drive_ceiling + stiction_ramp), capped at MOVE_MAX_DUTY
 ```
 
-The two speed-limit lines are inactive unless a speed limit was requested, and
-`drive_ceiling` reaches `MOVE_MAX_DUTY` within about 100 ms, so on a normal move
-this reduces to PD + feedforward + stall escape.
+**This is cascade control**: an outer position loop that asks for a velocity,
+and an inner velocity loop that delivers it. Worth seeing in those terms,
+because the previous flat form hid it - `u = KP*e - KD*v + FF` factors exactly
+as `FF + KD*((KP/KD)*e - v)`, which is the same loop with `v_ref = (KP/KD)*e`
+and gain `KD`. `MOVE_VREF_SLOPE` is that `KP/KD` ratio and keeps its old value
+of 50/s; `MOVE_KV` is that `KD`.
 
-Five ideas, each solving a specific measured problem:
+Two things follow from writing it out, and both were real bugs in the flat form:
 
-**Feedforward** supplies the breakaway duty so the P term only has to set speed
-rather than fight stiction. Deliberately set *above* the breakaway measured on
-any single fader, and centred in the range that keeps every move settling - not
-tuned for best accuracy on the reference unit. See "Tuning for hardware
-variance" below; this is the single most important thing to understand before
-changing these numbers.
+- **The inner loop's open-loop gain is `k * KV`**, not `KV`. `k` is the plant's
+  ADC counts/sec per duty, so a higher-torque motor closes a proportionally
+  hotter loop. Through the lag of the velocity estimate it goes underdamped and
+  the fader oscillates *on velocity* - overshoot, brake, fall under,
+  re-accelerate - which is not a position overshoot and does not look like one
+  on the bench; it looks like the movement is chugging. `KV` is therefore
+  scaled by `1/k` on a characterised unit, holding `k*KV` at the 1.16 the
+  reference fader was tuned at.
+- **The feedforward has to depend on the requested speed.** Inverting the plant
+  gives `u_ff = breakaway + v_ref/k` exactly, so at steady state the feedback
+  term is zero and the carriage simply travels at `v_ref`. A *fixed*
+  feedforward instead commands whatever speed it commands - ~1100 ADC/s on the
+  reference unit - and nothing slower is reachable without subtracting drive
+  back off, which is what the old one-sided governor did. See "Optional speed
+  limiting" below for why that misbehaved.
 
-**Derivative** is what prevents overshoot. Drive falls below breakaway when
-`KP*error ≈ KD*velocity`, i.e. at `v = (KP/KD)*error`. With KP 2.0 and KD 0.04
-that is 50/s, against a coast limit of `1/tau ≈ 200/s`. The controller
-therefore cuts drive about four stopping distances short and coasts in. The old
-code had no D term and a constant `+80` offset, so it drove at full authority
-right up to the deadband and arrived at ~12000 raw/s - which is precisely the
-58-80 raw overshoot it used to show.
+Five ideas, each solving a specific measured problem:Five ideas, each solving a specific measured problem:
+
+**Feedforward** is the plant model inverted: `breakaway + v_ref/k`. It supplies
+both the breakaway duty and the duty that produces the wanted speed, so the
+feedback term only has to correct the error in that model. Both halves are
+measured per unit (see "Per-unit motor characterisation"); the compiled-in
+defaults are the reference unit's values, so an uncharacterised fader behaves
+as it always did.
+
+**The velocity loop** is what prevents overshoot. Because `v_ref` is
+`MOVE_VREF_SLOPE * error`, the controller is asking the carriage to be slower
+the closer it gets, and drive falls away when it is travelling faster than
+that. At 50/s against a coast limit of `1/tau ~ 200/s` it cuts about four
+stopping distances short and coasts in. The old code had no such term and a
+constant `+80` offset, so it drove at full authority right up to the deadband
+and arrived at ~12000 raw/s - precisely the 58-80 raw overshoot it used to
+show.
 
 **Stiction ramp** fixes a genuine failure, not just feel. Because FF sits below
 breakaway, small errors produce `FF + KP*error` below breakaway: the controller
 commands motion it cannot produce, sits stuck outside the deadband, and after
 8 s falls into `MODE_ERROR`. The ramp adds drive at `MOVE_RAMP_RATE` only while
-commanded-but-stalled, capped at `MOVE_RAMP_MAX`, and is dropped the moment the
-carriage moves so it never contributes to overshoot. The cap also means a
-jammed fader cannot wind up to full drive.
+commanded-but-stalled, capped at `MOVE_RAMP_MAX`. The cap also means a jammed
+fader cannot wind up to full drive.
+
+It is shed at `MOVE_RAMP_DECAY_RATE` once the carriage breaks free - fast
+(~20 ms from full, far shorter than the coast time, so it still cannot
+contribute to overshoot) but **not instantly**. Dropping up to 70 duty in one
+tick is itself a relay, and sitting near `MOVE_STALL_VELOCITY` it chatters:
+wind up, break free, dump the drive, stall again. With the feedforward now
+derived to clear breakaway this should rarely engage at all during a normal
+move; it covers measurement error, a cold or stiff unit, and the
+uncharacterised case.
 
 **Take-up ceiling** addresses belt backlash. A direction-reversed move otherwise
 starts at full duty into slack: the rotor free-runs unloaded, then snaps taut
@@ -134,12 +163,13 @@ development:
   ceiling lifts partway through the slack and full duty still lands on
   engagement. Time is the only available signal that doesn't depend on whether
   the belt has taken up.
-- **`MOVE_TAKEUP_DUTY` must stay above `MOVE_FF_RISING/FALLING`.** The ceiling
-  exists to stop drive stepping to full duty, not to suppress the feedforward.
-  Set below FF it starves the term that gets the carriage moving: the fader
-  stalls, waits for the stiction ramp, and breaks free abruptly - which hunts
-  *and* makes the click worse. This regressed when FF was re-centred upward and
-  the ceiling was left at its old value.
+- **The ceiling must stay above the feedforward.** It exists to stop drive
+  stepping to full duty, not to suppress the feedforward. Set below it, it
+  starves the term that gets the carriage moving: the fader stalls, waits for
+  the stiction ramp, and breaks free abruptly - which hunts *and* makes the
+  click worse. This regressed once already, when the feedforward was re-centred
+  upward and the ceiling was left at its old value, which is why the derivation
+  now computes the ceiling from the feedforward rather than storing it loose.
 
 **Optional speed limit** (see below) is off by default and changes nothing when
 unset.
@@ -168,41 +198,47 @@ At 250 us the loop saturates (loop rate == tick rate) with no margin; don't.
 | constant | value | effect |
 |---|---|---|
 | `CONTROL_TICK_US` | 500 | 2 kHz. Higher rates gain little; the limit is friction, not sample rate. |
-| `MOVE_KP` | 2.0 | Approach speed. 3.0+ oscillates. |
-| `MOVE_KD` | 0.04 | Damping. Main speed/robustness dial - see below. |
-| `MOVE_FF_RISING/FALLING` | 106 / 124 | Per-direction friction feedforward, centred for hardware variance. Do not lower. |
-| `MOVE_DEADBAND` | 6.0 | On-target window. Has a hard floor - see below. Don't lower it. |
+| `MOVE_VREF_SLOPE` | 50 | ADC/s of velocity reference per ADC count of error. The old `KP/KD`. Higher approaches faster and coasts in from further out. |
+| `MOVE_KV` | 0.04 | Velocity loop gain. **Default only** - scaled by `1/k` on a characterised unit, because `k*KV` is what sets damping. |
+| `MOVE_BD_RISING/FALLING` | 68 / 86 | Assumed per-direction breakaway duty. **Default only** - measured on a characterised unit. |
+| `MOVE_K_DEFAULT` | 29 | Assumed ADC counts/sec per duty. **Default only** - measured. |
+| `MOVE_VEL_MIN` | 560 | Floor on the velocity reference, and so on the feedforward's clearance above breakaway. |
+| `MOVE_DEADBAND` | 8.0 | On-target window - the final error at which a move is declared arrived. Has a hard floor set by the plant - see below. Don't lower it. Derived per unit when characterised. |
 | `MOVE_STALL_VELOCITY` | 60 | "Not moving" threshold, for the stiction ramp. |
 | `MOVE_RAMP_RATE/MAX` | 250 / 70 | Stall escape strength. |
-| `MOVE_TAKEUP_DUTY` | 130 | Drive ceiling at move start. Must stay above FF. |
+| `MOVE_RAMP_DECAY_RATE` | 3500 | How fast the stall escape sheds once moving. Finite, not instant - see below. |
+| `MOVE_TAKEUP_DUTY` | 130 | Drive ceiling at move start. Must stay above FF, which is why it is derived from FF on a characterised unit. |
 | `MOVE_TAKEUP_RAMP_RATE` | 1200 | Duty/sec the ceiling opens up. Lower = gentler start. |
-| `MOVE_VEL_LIMIT_GAIN` | 0.08 | Speed-limit governor authority. |
-| `MOVE_VELOCITY_PER_ERROR` | 30 | Measured ADC/s of cruise per ADC of error. |
-| `MOVE_VEL_MIN` | 560 | Slowest smoothly sustainable speed (ADC/s). |
 | `MOVE_SPEED_SLOWEST_MS` | 700 | Full-travel time at host speed 0. The slow end of the validated window. |
 | `MOVE_SPEED_FASTEST_MS` | 250 | Full-travel time at host speed 254. Faster than this the limiter stops biting. |
 | `MOVE_TIMEOUT_TOLERANCE` | 20 | On timeout, error below this goes idle instead of `MODE_ERROR`. |
 
 **The deadband has a floor set by the plant, not by taste.** Nothing moves
-below breakaway, and at breakaway speed jumps straight to ~900 raw/s, so the
-smallest correction the fader can make is that speed times the reaction plus
-stopping time - about 10-16 raw, i.e. 5-8 ADC counts. Set the deadband below
-that floor and a fader whose breakaway does not match the feedforward constants
-will step past the window in both directions indefinitely and trip the movement
-timeout. This was a real field failure: 2.5 worked on the fader the gains were
-tuned against, where fine control was possible, and hung on a different one.
-There is nothing to gain by tightening it either - 6 ADC counts is about 1.5 LSB
-of the 8-bit position the host actually sees.
+below breakaway, and at breakaway speed jumps straight to `v_jump`, so the
+smallest correction the fader can make is that speed times the time it takes to
+actually stop. A deadband below that floor cannot be satisfied: the controller
+steps past the window in both directions forever, which looks like dithering at
+the end of a move and eventually trips the movement timeout.
 
-`MOVE_TIMEOUT_TOLERANCE` is the backstop for the same problem. On movement
-timeout, an error small enough to mean "arrived but hunting" goes quietly idle;
-only a genuinely large error (jam, dead motor, target outside the calibrated
-range) still latches `MODE_ERROR`, which needs a host round-trip to clear.
+**That stopping time is not the coast time.** Coast-down is first order with
+tau ~5 ms, so the carriage travels ~`v * 6 ms` after drive is cut - but the
+controller does not cut drive the instant the carriage reaches the window. The
+position filter and the control tick both have to notice first, and the
+carriage keeps moving throughout. The reference unit's measured minimum
+correction of 5-8 ADC counts at 450-560 ADC/s implies **9-18 ms end to end**,
+two to three times the coast alone. `MOTORCAL_STOP_TIME_MS` is 15 ms for that
+reason; sizing it at 6 produced a window a looser fader could not land in.
 
-**KD is the speed/robustness tradeoff.** Lower is faster but rings sooner;
-higher is smoother but slower to settle. Lowering KD is mathematically
-equivalent to adding carriage mass, since both make the carriage coast further,
-so a KD sweep doubles as an inertia sweep. Measured on the jig:
+The error is worth making in the generous direction. Too small and the fader
+dithers and times out; too large and the final position is slightly off, which
+at these sizes is 2-5 LSB of the 8-bit position the host sees. The first is a
+failure, the second is a rounding difference.
+
+**`k*KV` is the speed/robustness tradeoff**, and it is the product that
+matters, not `KV` alone. Lower is faster but rings sooner; higher is smoother
+but slower to settle. Lowering it is mathematically equivalent to adding
+carriage mass, since both make the carriage coast further, so a sweep of it
+doubles as an inertia sweep. Measured on the jig at `k*KV` 1.16:
 
 | effective inertia | 1.0x | 1.5x | 2.0x | 3.0x |
 |---|---|---|---|---|
@@ -210,8 +246,13 @@ so a KD sweep doubles as an inertia sweep. Measured on the jig:
 
 So the tuning tolerates roughly 1.5-2x the *total* moving inertia (carriage +
 belt + reflected rotor inertia) before ringing returns. A plastic knob cap is a
-few grams against that and is not a concern. KD 0.04 rather than 0.03 was chosen
-to widen this margin; the cost is ~40 ms on a full-travel move.
+few grams against that and is not a concern.
+
+**This is why `k` has to be measured.** Leave `KV` at a fixed 0.04 and a fader
+with `k` 60 instead of 29 runs `k*KV` of 2.4 - past the 2.0x column above, into
+the regime where the loop rings. It shows up as velocity chugging during the
+move rather than as position overshoot at the end, which is why it is easy to
+misread as a speed-limiter problem.
 
 ## Tuning for hardware variance
 
@@ -262,10 +303,100 @@ every deadband from 3 to 9 and every take-up value from 70 to 150 settles 7/7.
 That insensitivity is the point - if a change makes behaviour depend sharply on
 one constant again, that is a regression even if the reference fader looks good.
 
-If a unit ever falls outside this window, the fix is per-unit calibration rather
-than re-centring the constants: extend self-calibration to ramp duty until
-motion starts in each direction and store the result in EEPROM next to
-`calib_min`/`calib_max`, or have the stiction ramp learn and persist an offset.
+### The other failure: a unit with LESS friction than the reference
+
+Centring FF buys tolerance, but it does not make the design unit-independent,
+and the failure at the low-friction end is the mirror image of the one above.
+Near the target the slowest motion the controller can command is the
+equilibrium of `u = KP*e + FF - KD*v` against the plant:
+
+```
+v_min = k * (KP*deadband + FF - breakaway) / (1 + k*KD)
+```
+
+and a move can only settle if `v_min * (stopping time)` fits inside the
+deadband. On the reference unit (breakaway 68, k 29) that is
+`29*(12 + 106 - 68)/2.16 = 670` ADC/s, about 4 counts of stopping distance
+inside a 6 count window. On a unit whose breakaway is 40 and whose `k` is 40,
+the same constants give `40*(12 + 106 - 40)/2.6 = 1200` ADC/s and 7.2 counts -
+**larger than the deadband**. The fader cannot make a correction small enough
+to land in the window, so it steps past, reverses, steps past again, and hunts
+until the movement timeout.
+
+That is what a brand-new, looser fader looks like on the bench: jerky, worst at
+low commanded speeds, and never quite arriving. It is not fixable by raising the
+deadband (the window would have to grow past what the host can see) and it is
+not fixable by lowering FF globally, because that reintroduces the stall failure
+on stiffer units. The gap between FF and breakaway has to be a *per-unit*
+quantity.
+
+## Per-unit motor characterisation
+
+Self-calibration therefore measures the plant as well as the endpoints, and the
+gains above become defaults that a characterised unit overwrites. Three numbers
+per direction, in `MotorCalData`, persisted in the same EEPROM record as
+`calib_min`/`calib_max` and reported at `REG_MOTOR_CAL` (0x12):
+
+| measured | what it is |
+|---|---|
+| `bd` | breakaway duty - the duty at which the carriage first moves at all |
+| `k` | ADC counts/sec of cruise gained per duty count above breakaway |
+| `vjump` | the speed motion starts at once breakaway is crossed (Stribeck) |
+
+**The measurement.** Each run parks at the end it will travel away from, brakes
+for 200 ms (breakaway from a standstill is a different number from the duty
+needed to *sustain* motion, so residual coast would corrupt it), then ramps duty
+at ~80/sec until speed exceeds a motion threshold - that duty is `bd`. It holds
+there for 40 ms taking the peak speed, which is `vjump`, then dwells at `bd+25`
+and `bd+50` for 100 ms each, averaging the tail of each hold. The two dwell
+speeds give a two-point fit for `k`. Runs alternate direction so each starts
+where the last ended, two passes per direction, averaged. Anything implausible
+(`bd` outside 10..180, `k` outside 8..90, a run reaching the calibrated ends)
+discards the whole characterisation and keeps the compiled-in defaults - a
+half-measured fader is worse than an un-measured one.
+
+**What is derived** (`apply_motor_calibration`):
+
+```
+breakaway, k  ->  straight into the feedforward, u_ff = bd + v_ref/k
+KV            =  1.16 / k        (holds the inner loop's gain k*KV constant)
+vel_min       =  clamp(1.25 * vjump, 200, 1500)
+deadband      =  clamp(vel_min * 15 ms, 8, 20)
+takeup        =  max(130, max_dir(bd + vel_min/k) + 20)
+```
+
+The compiled-in defaults are themselves a plant model - breakaway 68/86, `k`
+29, `vjump` 448 - so there is one derivation rather than one per case, and an
+uncharacterised fader provably runs the gains the constants were tuned to.
+
+**On a unit that has never been characterised** - or whose measurement failed -
+every derived value falls back to the constant in the table above, so the
+behaviour is exactly the pre-1.2 firmware. `REG_MOTOR_CAL` byte 0 says which
+case a fader is in.
+
+## Flash budget
+
+Worth knowing before adding anything here: **the ATtiny1616's 16 KB is the
+binding constraint on this file**, and the I2C bootloader work reserves the top
+2 KB, leaving **14336 bytes for the application**. The characterisation above
+was written to fit that, which is why the measurement and the derivation are
+integer throughout and the ramp is fixed point - the float versions of the same
+logic cost roughly 1.3 KB more and did not fit.
+
+Three unrelated savings were taken at the same time and are worth not undoing:
+
+- `main.cpp` no longer includes `<megaTinyCore.h>`. Nothing used it, but its
+  ADC-error helpers take `HardwareSerial&` default arguments, which under LTO
+  pulls all of `UART0.cpp` - both USART ISRs and the `Print`/`HardwareSerial`
+  machinery - into a build with `SERIAL_ENABLED` off. **800 bytes of flash and
+  145 of RAM.**
+- The heartbeat LED and `nSLEEP` go straight to `VPORTB` rather than through
+  `digitalWrite()`, which is 160 bytes of pin lookup for two call sites.
+- `onI2cRequest` builds multi-byte replies through `i2c_write_u16`/`u32` helpers
+  instead of writing bytes out at each call site.
+
+If a future change does not fit, measure before trimming: build, then
+`avr-nm -S --size-sort -C .pio/build/fader_buddy/firmware.elf | tail -20`.
 
 ## Optional speed limiting
 
@@ -291,15 +422,25 @@ without changing the host-facing meaning of the byte. The cost is that "how
 long will this move take" is no longer readable off the parameter, which is
 honest: it was never accurate to better than ~15% anyway.
 
-It takes **two cooperating parts**, and neither works alone - this is the part
-worth understanding before touching it:
+**It is realised by clamping the velocity reference**, and nothing else - one
+line in the control law. Because the feedforward is `breakaway + v_ref/k`, a
+lower reference directly means less drive, so the requested speed is produced
+rather than fought for.
 
-- **An error clamp**, so the proportional term cannot saturate. On a large move
-  `KP*error` is around 1300 duty, so the governor below has no authority
-  whatsoever against the 254 ceiling.
-- **A one-sided governor** on measured velocity, so drive can be pulled *below*
-  the feedforward. FF alone commands ~2200 raw counts/sec, so clamping the error
-  can only slow the fader to that floor and never under it.
+That is worth stating against what it replaced, because the earlier design is
+an instructive failure. With a *fixed* feedforward the drive alone commanded
+~1100 ADC/s regardless of the request, so clamping the error could never slow
+the fader below that floor. Two extra parts were bolted on to work around it:
+an error clamp to stop the P term saturating, and a **one-sided governor** that
+subtracted drive once measured velocity exceeded the limit.
+
+A one-sided correction puts the operating point exactly on its own
+discontinuity: below the limit it contributes nothing at all, above it a lagged
+correction. That is a limit-cycle generator, and it behaved like one - overshoot
+the limit, brake hard, fall under, accelerate again, most visible at low
+requested speeds where the cycle is a large fraction of the commanded velocity.
+Both parts are gone; the plant-inverting feedforward removed the floor that
+made them necessary.
 
 Measured on the reference fader, requesting a full-scale time and timing a move
 of 67% of full scale:
@@ -309,13 +450,20 @@ of 67% of full scale:
 | measured | 193 ms | 261 ms | 356 ms | 444 ms | 584 ms | 759 ms |
 | vs expected | +16% | -2% | -11% | -17% | -27% | -43% |
 
-**Usable range is roughly 250 ms to 700 ms of full-scale time**, tracking within
-about 15% - hence those two endpoints for the speed scale. Beyond the slow end
-it saturates: there is a hard floor below which the motor cannot sustain
-continuous rotation and creeps in stick-slip steps rather than moving smoothly.
-`MOVE_VEL_MIN` (560 ADC counts/sec, ~1.7 s of full travel on the reference unit)
-is the backstop clamp for that, and sits well below anything the speed scale can
-ask for. Slower smooth motion is not reachable by tuning - it needs a different
+**Usable range is roughly 250 ms to 700 ms of full-scale time**, hence those two
+endpoints for the speed scale. Those figures were measured against the old
+governor, whose tracking error ran to -43% at the slow end; the reference-clamp
+form should track considerably better, since the feedforward now produces the
+requested speed directly instead of being pulled back down to it. **Re-measure
+that table** - it is the clearest single check that this change did what it was
+meant to.
+
+Beyond the slow end it still saturates: there is a hard floor below which the
+motor cannot sustain continuous rotation and creeps in stick-slip steps rather
+than moving smoothly. `move_vel_min` (1.25x the measured Stribeck jump, 560 ADC
+counts/sec by default) is the clamp for that, and it is now also the floor the
+velocity reference is held at even next to the target - which is what keeps the
+feedforward clear of breakaway for small errors. Slower smooth motion is not reachable by tuning - it needs a different
 drive scheme. Direction asymmetry is within about 7%.
 
 Treat this as a *limit*, not a precise speed control - it is realised through
@@ -345,13 +493,19 @@ cd production_tools/programAndTest && pio run -e lab -t upload
 `openloop` and `stopdist` drive the bridge directly for system ID, `dbg` reads
 control-loop internals, and `gain <index> <value>` overrides any tuning constant
 at runtime so a gain sweep does not need a reflash per trial. Gain indices are
-in `i2c_data.h` (`DEBUG_GAIN_*`); KP, KD and deadband are scaled by 1000.
+in `i2c_data.h` (`DEBUG_GAIN_*`); the reference slope, KV and deadband are
+scaled by 1000.
 
 Restore production firmware with `pio run -e fader_buddy -t upload` and
 `pio run -e lilygo-t-display -t upload`.
 
 The debug registers (0xF0-0xF2) are additive and compiled out unless
 `DEBUG_DRIVE` is defined, so the protocol version is unchanged.
+
+`REG_MOTOR_CAL` (0x12) is *not* debug-only and is present in production builds,
+so a unit's measured breakaway, slope and jump speed can be read on a bench with
+nothing but an I2C host attached - no jig, no lab firmware, no programmer. The
+ESPHome component logs all of it at startup.
 
 ## Measurement gotchas
 

--- a/firmware/ABOUT_MOTOR_CONTROL.md
+++ b/firmware/ABOUT_MOTOR_CONTROL.md
@@ -413,9 +413,13 @@ If a future change does not fit, measure before trimming: build, then
 
 `LAYER_TARGET` (0x0E) takes an optional 4th byte capping the speed of the move.
 Three-byte writes behave exactly as before, so this is backwards compatible and
-does not change the protocol version. Hosts should keep sending 3-byte writes
-for full-speed moves: firmware predating the byte ignores a 4-byte write
-entirely rather than moving.
+does not change the protocol version.
+
+A host that uses the byte should send it on every move, 255 included. The byte
+sets the layer's *stored* speed, and a 3-byte write leaves that alone - so
+falling back to 3 bytes for a full-speed move silently re-applies whatever limit
+the layer last held. Send 3 bytes only to firmware predating the byte, which
+ignores a 4-byte write entirely rather than moving.
 
 The byte is a **unitless 0-255 speed**: 255 (the default) is unlimited, and 0 is
 the slowest the mechanism moves smoothly. Values below 255 map linearly in

--- a/firmware/ABOUT_MOTOR_CONTROL.md
+++ b/firmware/ABOUT_MOTOR_CONTROL.md
@@ -1,8 +1,13 @@
 # About: motor control and closed-loop tuning
 
-Notes for whoever next touches the movement code in `src/main.cpp`. Covers the
-plant model, why the control law is shaped the way it is, what each constant
-does, and how to re-measure everything on hardware.
+Notes for whoever next touches the movement code. Covers the plant model, why
+the control law is shaped the way it is, what each constant does, and how to
+re-measure everything on hardware.
+
+Three files: `src/motor_control.h` holds the drive primitives and every `MOVE_*`
+constant; `src/main.cpp` runs the control law and owns the mode state machine;
+`src/motor_cal.cpp` measures the plant during self-calibration and re-derives
+the gains from it.
 
 ## Units
 
@@ -74,7 +79,7 @@ the feel. If you ever do switch them, those constants must be retuned together.
 
 ## The control law
 
-In `motor_update()`, `MODE_REMOTE_MOVEMENT_IN_PROGRESS`:
+In `main.cpp`'s `motor_update()`, `MODE_REMOTE_MOVEMENT_IN_PROGRESS`:
 
 ```
 error = target_adc - input_ewma
@@ -115,7 +120,7 @@ Two things follow from writing it out, and both were real bugs in the flat form:
   back off, which is what the old one-sided governor did. See "Optional speed
   limiting" below for why that misbehaved.
 
-Five ideas, each solving a specific measured problem:Five ideas, each solving a specific measured problem:
+Five ideas, each solving a specific measured problem:
 
 **Feedforward** is the plant model inverted: `breakaway + v_ref/k`. It supplies
 both the breakaway duty and the duty that produces the wanted speed, so the
@@ -152,10 +157,16 @@ uncharacterised case.
 **Take-up ceiling** addresses belt backlash. A direction-reversed move otherwise
 starts at full duty into slack: the rotor free-runs unloaded, then snaps taut
 with an audible click and a jerk. The drive ceiling therefore starts at
-`MOVE_TAKEUP_DUTY` at the beginning of every move and opens up to full over
-time at `MOVE_TAKEUP_RAMP_RATE`.
+`MOVE_TAKEUP_DUTY` and opens up to full over time at `MOVE_TAKEUP_RAMP_RATE`.
 
-Two things about this are easy to get wrong, and both were bugs during
+It is re-armed when a move is commanded in the opposite direction to the one in
+progress, not on every write to `LAYER_TARGET`. Slack is only taken up on a
+reversal, and a host that streams position updates - an LVGL slider being
+dragged, say - retargets many times a second; re-arming on each of those would
+hold the ceiling at the take-up duty for the whole gesture and cap the fader at
+roughly half speed.
+
+Three things about this are easy to get wrong, and all were bugs during
 development:
 
 - **It must be time-based, not gated on "are we moving yet".** While crossing
@@ -355,7 +366,7 @@ where the last ended, two passes per direction, averaged. Anything implausible
 discards the whole characterisation and keeps the compiled-in defaults - a
 half-measured fader is worse than an un-measured one.
 
-**What is derived** (`apply_motor_calibration`):
+**What is derived** (`apply_motor_calibration`, in `motor_cal.cpp`):
 
 ```
 breakaway, k  ->  straight into the feedforward, u_ff = bd + v_ref/k
@@ -458,13 +469,19 @@ requested speed directly instead of being pulled back down to it. **Re-measure
 that table** - it is the clearest single check that this change did what it was
 meant to.
 
-Beyond the slow end it still saturates: there is a hard floor below which the
-motor cannot sustain continuous rotation and creeps in stick-slip steps rather
-than moving smoothly. `move_vel_min` (1.25x the measured Stribeck jump, 560 ADC
-counts/sec by default) is the clamp for that, and it is now also the floor the
-velocity reference is held at even next to the target - which is what keeps the
-feedforward clear of breakaway for small errors. Slower smooth motion is not reachable by tuning - it needs a different
-drive scheme. Direction asymmetry is within about 7%.
+Beyond the slow end it saturates: there is a hard floor below which the motor
+cannot sustain continuous rotation and creeps in stick-slip steps rather than
+moving smoothly. Slower smooth motion is not reachable by tuning - it would need
+a different drive scheme.
+
+`move_vel_min` (1.25x the measured Stribeck jump, 560 ADC counts/sec by default)
+is the clamp for that floor. It is applied to the velocity reference in the
+control law, every tick, and nowhere else - not where the speed byte is decoded,
+which would freeze it against a `move_vel_min` that calibration can change
+afterwards. It is also the floor the reference is held at right next to the
+target, which is what keeps the feedforward clear of breakaway for small errors.
+
+Direction asymmetry is within about 7%.
 
 Treat this as a *limit*, not a precise speed control - it is realised through
 the friction-dependent plant, so exact velocity varies with the fader.

--- a/firmware/ABOUT_MOTOR_CONTROL.md
+++ b/firmware/ABOUT_MOTOR_CONTROL.md
@@ -91,7 +91,7 @@ else:
     clamp |u| to (drive_ceiling + stiction_ramp), capped at MOVE_MAX_DUTY
 ```
 
-The two speed-limit lines are inactive unless a move time was requested, and
+The two speed-limit lines are inactive unless a speed limit was requested, and
 `drive_ceiling` reaches `MOVE_MAX_DUTY` within about 100 ms, so on a normal move
 this reduces to PD + feedforward + stall escape.
 
@@ -179,6 +179,8 @@ At 250 us the loop saturates (loop rate == tick rate) with no margin; don't.
 | `MOVE_VEL_LIMIT_GAIN` | 0.08 | Speed-limit governor authority. |
 | `MOVE_VELOCITY_PER_ERROR` | 30 | Measured ADC/s of cruise per ADC of error. |
 | `MOVE_VEL_MIN` | 560 | Slowest smoothly sustainable speed (ADC/s). |
+| `MOVE_SPEED_SLOWEST_MS` | 700 | Full-travel time at host speed 0. The slow end of the validated window. |
+| `MOVE_SPEED_FASTEST_MS` | 250 | Full-travel time at host speed 254. Faster than this the limiter stops biting. |
 | `MOVE_TIMEOUT_TOLERANCE` | 20 | On timeout, error below this goes idle instead of `MODE_ERROR`. |
 
 **The deadband has a floor set by the plant, not by taste.** Nothing moves
@@ -269,14 +271,25 @@ motion starts in each direction and store the result in EEPROM next to
 
 `LAYER_TARGET` (0x0E) takes an optional 4th byte capping the speed of the move.
 Three-byte writes behave exactly as before, so this is backwards compatible and
-does not change the protocol version.
+does not change the protocol version. Hosts should keep sending 3-byte writes
+for full-speed moves: firmware predating the byte ignores a 4-byte write
+entirely rather than moving.
 
-The byte is **the time a full-scale (0 -> 255) move should take, in units of
-10 ms**; 0 means unlimited. So 100 means "one second for full travel", and the
-range is 10 ms .. 2550 ms. It is a velocity cap, not a move scheduler: a shorter
-move takes proportionally less time rather than being stretched to fill the
-duration. The conversion is just `velocity = span / time`, with no scaling
-constant to keep in sync.
+The byte is a **unitless 0-255 speed**: 255 (the default) is unlimited, and 0 is
+the slowest the mechanism moves smoothly. Values below 255 map linearly in
+*velocity* across `MOVE_SPEED_SLOWEST_MS` .. `MOVE_SPEED_FASTEST_MS`, which are
+stated as full-travel times because that is how the measurements below were
+taken; the calibrated span turns each into a velocity.
+
+The scale is deliberately unitless rather than a move time in ms. The usable
+window is narrow and bounded at both ends by the plant - past the fast end the
+limiter stops having any effect, past the slow end the mechanism stick-slips -
+so a physical-units parameter mostly offers values that do nothing or cannot be
+honoured. Mapping the whole byte onto the validated window means every value a
+host can send does something, and the endpoints can be re-measured and moved
+without changing the host-facing meaning of the byte. The cost is that "how
+long will this move take" is no longer readable off the parameter, which is
+honest: it was never accurate to better than ~15% anyway.
 
 It takes **two cooperating parts**, and neither works alone - this is the part
 worth understanding before touching it:
@@ -297,15 +310,20 @@ of 67% of full scale:
 | vs expected | +16% | -2% | -11% | -17% | -27% | -43% |
 
 **Usable range is roughly 250 ms to 700 ms of full-scale time**, tracking within
-about 15%. Beyond that it saturates: there is a hard floor near **1.1 s of
-full travel** (~200 position counts/sec), below which the motor cannot sustain
+about 15% - hence those two endpoints for the speed scale. Beyond the slow end
+it saturates: there is a hard floor below which the motor cannot sustain
 continuous rotation and creeps in stick-slip steps rather than moving smoothly.
-Requests slower than that are clamped, not honoured. Slower smooth motion is not
-reachable by tuning - it needs a different drive scheme. Direction asymmetry is
-within about 7%.
+`MOVE_VEL_MIN` (560 ADC counts/sec, ~1.7 s of full travel on the reference unit)
+is the backstop clamp for that, and sits well below anything the speed scale can
+ask for. Slower smooth motion is not reachable by tuning - it needs a different
+drive scheme. Direction asymmetry is within about 7%.
 
 Treat this as a *limit*, not a precise speed control - it is realised through
 the friction-dependent plant, so exact velocity varies with the fader.
+
+The lab jig's `sstep <from> <to> <speed> <log_ms>` command takes the same
+unitless byte, so re-measuring the table above means picking speeds rather than
+times.
 
 ## Reproducing the measurements
 
@@ -332,7 +350,7 @@ in `i2c_data.h` (`DEBUG_GAIN_*`); KP, KD and deadband are scaled by 1000.
 Restore production firmware with `pio run -e fader_buddy -t upload` and
 `pio run -e lilygo-t-display -t upload`.
 
-The debug registers (0x10-0x12) are additive and compiled out unless
+The debug registers (0xF0-0xF2) are additive and compiled out unless
 `DEBUG_DRIVE` is defined, so the protocol version is unchanged.
 
 ## Measurement gotchas

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -119,6 +119,41 @@ enum TapState : uint8_t {
 #define MOVE_DEADBAND (6.0f)            // ADC counts considered "on target"
 #define MOVE_MAX_DUTY (254)
 
+// Optional speed limiting. Cruise velocity is already proportional to error
+// (the plant is a velocity source, so v ~ kv*KP*e / (1 + kv*KD)), which is why
+// big moves are fast and small ones are slow. Capping the error fed to the P
+// term therefore caps cruise speed, with no extra state and no motion profile.
+// Near the target the error is below the cap, so the clamp is inactive and the
+// tuned decel/coast/settle behaviour is untouched.
+//
+// This is a limit, not a precise speed: the constant below is the measured
+// closed-loop velocity per unit of error on the reference fader, and it varies
+// by ~20% between directions (friction is direction-dependent) plus unit to
+// unit. Callers wanting an exact velocity need a governor closing the loop on
+// measured velocity instead.
+// Implemented as a one-sided governor on measured velocity rather than by
+// clamping the error: the feedforward sits well above breakaway (deliberately,
+// for hardware tolerance), so it alone commands ~2200 raw counts/sec. Clamping
+// the error can only slow the fader to that floor, whereas subtracting from the
+// drive pulls it below the feedforward and reaches the real limit - the
+// Stribeck floor of ~900 raw counts/sec, below which the mechanism stick-slips
+// rather than moving smoothly.
+// Two cooperating parts are needed, and neither works alone:
+//  - the error clamp stops the P term saturating. For a large move KP*error is
+//    ~1300 duty, so the governor below cannot pull it under the 254 ceiling.
+//  - the governor pulls drive below the feedforward. The feedforward alone
+//    commands ~2200 raw counts/sec, so clamping the error can only slow the
+//    fader to that floor, never under it.
+#define MOVE_VELOCITY_PER_ERROR (30.0f)  // ADC counts/sec per ADC count of error
+#define MOVE_VEL_LIMIT_GAIN (0.08f)      // duty per (ADC count/sec) of overspeed
+// Slowest speed the mechanism sustains smoothly. Below roughly this the motor
+// cannot maintain continuous rotation (Stribeck friction) and creeps in
+// stick-slip steps instead, so requests slower than this are clamped rather
+// than honoured. Measured floor is ~150 position counts/sec, i.e. full travel
+// in about 1.7 s.
+#define MOVE_VEL_MIN (560.0f)            // ADC counts/sec
+#define MOVE_VEL_UNLIMITED (0.0f)
+
 // On movement timeout, an error this small means the fader is essentially in
 // position and merely hunting - give up quietly rather than latching
 // MODE_ERROR, which needs a host round-trip to clear. Anything larger is a
@@ -145,7 +180,23 @@ enum TapState : uint8_t {
 // drive is therefore capped just above breakaway: enough to cross the slack
 // promptly, but slow enough that engagement is gentle. Full authority returns
 // as soon as the carriage is actually moving, so this costs only a few ms.
-#define MOVE_TAKEUP_DUTY (95)           // duty ceiling while stalled (0 = disabled)
+// Backlash take-up. A direction-reversed move starts with the motor unloaded,
+// so commanding full duty lets the rotor spin up through the slack and snap it
+// taut - an audible click and a jerk at the carriage. The drive ceiling
+// therefore starts low at the beginning of every move and opens up over time.
+//
+// This is deliberately time-based rather than gated on "are we moving yet":
+// while crossing the slack the rotor IS moving (it just isn't loaded), so a
+// velocity-gated ceiling lifts partway through the slack and full duty still
+// lands on engagement. Time is the only signal available that does not depend
+// on whether the belt has taken up yet.
+// MUST stay above MOVE_FF_RISING/FALLING. The ceiling exists to stop the drive
+// stepping to full duty, not to suppress the feedforward: set below FF it
+// starves the very term that gets the carriage moving, so the fader stalls,
+// waits for the stiction ramp, and breaks free abruptly - which both hunts and
+// makes the click worse rather than better.
+#define MOVE_TAKEUP_DUTY (130)           // duty ceiling at the start of a move
+#define MOVE_TAKEUP_RAMP_RATE (1200.0f)  // duty per second the ceiling opens up
 
 #if DEBUG_DRIVE
 // Runtime-tunable copies, so gain sweeps don't need a reflash per trial.
@@ -156,6 +207,7 @@ int16_t move_ff_falling = MOVE_FF_FALLING;
 float move_deadband = MOVE_DEADBAND;
 float move_ramp_rate = MOVE_RAMP_RATE;
 int16_t move_takeup_duty = MOVE_TAKEUP_DUTY;
+float move_takeup_ramp_rate = MOVE_TAKEUP_RAMP_RATE;
 #else
 #define move_kp MOVE_KP
 #define move_kd MOVE_KD
@@ -164,11 +216,15 @@ int16_t move_takeup_duty = MOVE_TAKEUP_DUTY;
 #define move_deadband MOVE_DEADBAND
 #define move_ramp_rate MOVE_RAMP_RATE
 #define move_takeup_duty MOVE_TAKEUP_DUTY
+#define move_takeup_ramp_rate MOVE_TAKEUP_RAMP_RATE
 #endif
 
 const float ALPHA = 0.05;
 float input_ewma = 0;
 float stiction_ramp = 0;                // extra drive ramped in while stalled
+float move_max_velocity = MOVE_VEL_UNLIMITED;  // 0 = unlimited
+float move_max_error = 1023.0f;         // matching P-term clamp; large = inactive
+float drive_ceiling = MOVE_MAX_DUTY;    // take-up ceiling, reset at each move start
 float velocity_ewma = 0;                // ADC counts/sec, + toward the motor end
 float last_control_ewma = 0;
 uint32_t last_control_tick_us = 0;
@@ -212,6 +268,7 @@ uint8_t last_haptic_nonce = 0;  // Track last seen nonce to detect changes [DEPR
 // Layer state storage (27 bytes total) - Protocol v5+
 uint16_t layer_haptic_configs[8];      // 16 bytes - 16-bit haptic config per layer
 uint8_t layer_restore_positions[8];    // 8 bytes - restore position per layer (0-255)
+uint8_t layer_move_times[8];           // 8 bytes - optional full-travel move time per layer (0 = unlimited)
 uint8_t active_layer = 0;              // 1 byte - currently active layer (0-7)
 uint8_t pending_layer_change = 0xFF;   // 1 byte - deferred layer change (0xFF = none, 0-7 = layer)
 uint8_t queried_layer = 0;             // 1 byte - for layer-addressed read protocol
@@ -239,9 +296,11 @@ volatile uint8_t i2c_layer_change_request = 0xFF;  // 0xFF = none, 0-7 = layer
 struct LayerTargetWrite {
   uint8_t layer;
   uint8_t target;
+  uint8_t move_time; // optional full-travel move time (see LAYER_MOVE_TIME)
+  bool has_move_time;// false = 3-byte legacy write, leave the limit as-is
   bool valid;
 };
-volatile LayerTargetWrite i2c_layer_target_write = {0, 0, false};
+volatile LayerTargetWrite i2c_layer_target_write = {0, 0, 0, false, false};
 
 struct LayerHapticWrite {
   uint8_t layer;
@@ -313,6 +372,7 @@ void reset_tap_detection();
 void request_layer_change(uint8_t new_layer);
 void apply_layer_change(uint8_t new_layer);
 void write_layer_target(uint8_t layer, uint8_t target);
+void apply_move_time(uint8_t move_time_10ms);
 void write_layer_haptic_config(uint8_t layer, uint16_t config);
 
 Mode get_mode() {
@@ -322,9 +382,12 @@ Mode get_mode() {
 void set_mode(Mode mode) {
   state = (state & ~STATE_MODE_bm) | (mode << STATE_MODE_bp);
 
-  // Any fresh movement starts without accumulated stiction ramp
+  // Any fresh movement starts without accumulated stiction ramp, and with the
+  // drive ceiling back down so backlash is taken up gently.
   if (mode != MODE_REMOTE_MOVEMENT_IN_PROGRESS) {
     stiction_ramp = 0;
+  } else {
+    drive_ceiling = move_takeup_duty;
   }
 
   // Reset tap detection when entering modes where taps shouldn't be detected
@@ -475,12 +538,13 @@ void onI2cRequest() {
   } else if (r == REG_DEBUG_STATUS) {
       int16_t vel = (int16_t)debug_status_velocity;
       int16_t err_x8 = (int16_t)(debug_status_error * 8);
-      const uint16_t vals[8] = {
+      const uint16_t vals[9] = {
         input_calib_min, input_calib_max, (uint16_t)target_adc,
         (uint16_t)motor_drive_value, (uint16_t)vel, (uint16_t)err_x8,
         debug_status_loop_hz, debug_status_tick_hz,
+        (uint16_t)move_max_velocity,
       };
-      for (uint8_t i = 0; i < 8; i++) {
+      for (uint8_t i = 0; i < 9; i++) {
         Wire.write((vals[i] >> 8) & 0xFF);
         Wire.write(vals[i] & 0xFF);
       }
@@ -528,11 +592,14 @@ void onI2cReceive(int howMany) {
       if (howMany == 2) {
         // Read setup: register + layer index
         queried_layer = Wire.read() & 0x07;
-      } else if (howMany == 3) {
-        // Write: register + layer + target position
-        // Copy data to volatile struct for main loop to process
+      } else if (howMany == 3 || howMany == 4) {
+        // Write: register + layer + target position [+ optional speed limit].
+        // The 3-byte form is the original protocol and leaves the layer's
+        // existing speed limit alone, so old controllers are unaffected.
         i2c_layer_target_write.layer = Wire.read() & 0x07;
         i2c_layer_target_write.target = Wire.read();
+        i2c_layer_target_write.has_move_time = (howMany == 4);
+        i2c_layer_target_write.move_time = (howMany == 4) ? Wire.read() : 0;
         i2c_layer_target_write.valid = true;
       }
       break;
@@ -731,6 +798,7 @@ void apply_layer_change(uint8_t new_layer) {
     layer_restore_positions[new_layer], 0, 255,
     input_calib_min, input_calib_max
   );
+  apply_move_time(layer_move_times[new_layer]);
   remote_movement_start = millis();
   remote_movement_start_position = input_ewma;
   remote_movement_steady_start = millis();
@@ -753,6 +821,7 @@ void write_layer_target(uint8_t layer, uint8_t target) {
       // Start remote movement
       layer_restore_positions[layer] = target;
       target_adc = BOUNDED_LERP_UINT16(target, 0, 255, input_calib_min, input_calib_max);
+      apply_move_time(layer_move_times[layer]);
       set_mode(MODE_REMOTE_MOVEMENT_IN_PROGRESS);
       remote_movement_start = millis();
       remote_movement_start_position = input_ewma;
@@ -763,6 +832,7 @@ void write_layer_target(uint8_t layer, uint8_t target) {
       // Update target of in-progress movement
       layer_restore_positions[layer] = target;
       target_adc = BOUNDED_LERP_UINT16(target, 0, 255, input_calib_min, input_calib_max);
+      apply_move_time(layer_move_times[layer]);
       remote_movement_start = millis();
       remote_movement_start_position = input_ewma;
       remote_movement_steady_start = millis();
@@ -807,6 +877,29 @@ void adc_drain() {
     // 2x accumulation, so halve to get ADC counts
     input_ewma = adc_val * ALPHA / 2 + input_ewma * (1 - ALPHA);
   }
+}
+
+// Translate a layer's move-time byte into the velocity limit used by the
+// control law. The byte is the time a full-scale (0-255) move should take, in
+// units of 10 ms; 0 means unlimited. Since the whole calibrated span is crossed
+// in that time, the velocity is simply span/time.
+void apply_move_time(uint8_t move_time_10ms) {
+  if (move_time_10ms == LAYER_MOVE_TIME_UNLIMITED) {
+    move_max_velocity = MOVE_VEL_UNLIMITED;
+    move_max_error = 1023.0f;
+    return;
+  }
+  uint16_t span = input_calib_max - input_calib_min;
+  float ms = (float)move_time_10ms * LAYER_MOVE_TIME_MS_PER_UNIT;
+  float adc_per_sec = (float)span * 1000.0f / ms;
+  // Clamp to what the mechanism can actually sustain smoothly
+  if (adc_per_sec < MOVE_VEL_MIN) adc_per_sec = MOVE_VEL_MIN;
+  move_max_velocity = adc_per_sec;
+  // Matching error clamp, so the proportional term cannot saturate past the
+  // point where the governor has any authority.
+  float clamp = adc_per_sec / MOVE_VELOCITY_PER_ERROR;
+  if (clamp < MOVE_DEADBAND * 2) clamp = MOVE_DEADBAND * 2;
+  move_max_error = clamp;
 }
 
 void motor_update() {
@@ -908,13 +1001,21 @@ void motor_update() {
         }
         float error = target_adc - input_ewma;
         if (error > move_deadband || error < -move_deadband) {
-          // PD on position plus a friction feedforward sized just under the
-          // measured breakaway duty, so the controller only has to supply the
-          // part of the drive that sets speed rather than fighting stiction.
-          // The D term is what prevents overshoot: it cancels the feedforward
-          // while the carriage is still moving fast, cutting drive roughly one
-          // stopping distance short of the target so it coasts in.
-          float u = move_kp * error - move_kd * velocity_ewma;
+          // PD on position plus a friction feedforward, which covers the
+          // breakaway duty so the controller only has to supply the part of
+          // the drive that sets speed rather than fighting stiction. The D term
+          // is what prevents overshoot: it cancels the feedforward while the
+          // carriage is still moving fast, cutting drive roughly one stopping
+          // distance short of the target so it coasts in.
+
+          // Clamp the error driving the P term when a speed limit is active.
+          // Inactive near the target and when unlimited, so the tuned approach
+          // and settle behaviour is unchanged.
+          float e_ctrl = error;
+          if (e_ctrl > move_max_error) e_ctrl = move_max_error;
+          if (e_ctrl < -move_max_error) e_ctrl = -move_max_error;
+
+          float u = move_kp * e_ctrl - move_kd * velocity_ewma;
           u += (error > 0) ? move_ff_rising : -move_ff_falling;
 
           // Ramp in extra drive only while stalled, and shed it as soon as the
@@ -928,13 +1029,23 @@ void motor_update() {
           }
           u += (error > 0) ? stiction_ramp : -stiction_ramp;
 
-          // Cap drive until the carriage is moving, so the motor eases through
-          // belt backlash instead of snapping it taut at full duty.
-          int16_t limit = MOVE_MAX_DUTY;
-          if (move_takeup_duty > 0 && speed < MOVE_STALL_VELOCITY) {
-            limit = move_takeup_duty + (int16_t)stiction_ramp;
-            if (limit > MOVE_MAX_DUTY) limit = MOVE_MAX_DUTY;
+          // Optional velocity limit: bleed off drive only while over the
+          // requested speed, so approach and settle near the target (already
+          // slower than any useful limit) are unaffected.
+          if (move_max_velocity > MOVE_VEL_UNLIMITED) {
+            float speed_now = velocity_ewma < 0 ? -velocity_ewma : velocity_ewma;
+            if (speed_now > move_max_velocity) {
+              float excess = MOVE_VEL_LIMIT_GAIN * (speed_now - move_max_velocity);
+              u += (velocity_ewma > 0) ? -excess : excess;
+            }
           }
+
+          // Drive ceiling opens up over time from the take-up value, easing
+          // the motor through belt backlash instead of stepping to full duty.
+          drive_ceiling += move_takeup_ramp_rate * (control_dt_us * 1e-6f);
+          if (drive_ceiling > MOVE_MAX_DUTY) drive_ceiling = MOVE_MAX_DUTY;
+          int16_t limit = (int16_t)drive_ceiling + (int16_t)stiction_ramp;
+          if (limit > MOVE_MAX_DUTY) limit = MOVE_MAX_DUTY;
 
           int16_t drive = (int16_t)u;
           if (drive > limit) drive = limit;
@@ -1159,6 +1270,7 @@ void setup() {
   for (uint8_t i = 0; i < 8; i++) {
     layer_haptic_configs[i] = 0;  // Default: HAPTIC_NO_HAPTICS (smooth mode), all bits 0
     layer_restore_positions[i] = 128;  // Default: midpoint
+    layer_move_times[i] = LAYER_MOVE_TIME_UNLIMITED;
   }
   active_layer = 0;
   pending_layer_change = 0xFF;  // No pending change
@@ -1213,6 +1325,8 @@ void process_i2c_requests() {
   bool has_layer_target = false;
   uint8_t layer_target_layer = 0;
   uint8_t layer_target_target = 0;
+  uint8_t layer_target_move_time = 0;
+  bool layer_target_has_move_time = false;
   bool has_layer_haptic = false;
   uint8_t layer_haptic_layer = 0;
   uint16_t layer_haptic_config = 0;
@@ -1241,6 +1355,8 @@ void process_i2c_requests() {
     has_layer_target = true;
     layer_target_layer = i2c_layer_target_write.layer;
     layer_target_target = i2c_layer_target_write.target;
+    layer_target_move_time = i2c_layer_target_write.move_time;
+    layer_target_has_move_time = i2c_layer_target_write.has_move_time;
     i2c_layer_target_write.valid = false;
   }
 
@@ -1284,6 +1400,9 @@ void process_i2c_requests() {
   }
 
   if (has_layer_target) {
+    if (layer_target_has_move_time) {
+      layer_move_times[layer_target_layer & 0x07] = layer_target_move_time;
+    }
     write_layer_target(layer_target_layer, layer_target_target);
   }
 
@@ -1305,6 +1424,7 @@ void process_i2c_requests() {
       case DEBUG_GAIN_DEADBAND:   move_deadband = debug_gain_value / 1000.0f; break;
       case DEBUG_GAIN_RAMP_RATE:  move_ramp_rate = debug_gain_value; break;
       case DEBUG_GAIN_TAKEUP:     move_takeup_duty = debug_gain_value; break;
+      case DEBUG_GAIN_TAKEUP_RAMP: move_takeup_ramp_rate = debug_gain_value; break;
       // Override the calibration bounds (RAM only, not persisted) so a
       // miscalibrated fader - one whose stored range exceeds its physical
       // travel - can be reproduced on a good unit.

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -74,9 +74,111 @@ enum TapState : uint8_t {
   TAP_SECOND_PRESSED,          // Second tap touch detected
 };
 
+// Fixed-rate control tick. The control law needs a known, constant period so
+// the derivative term and the filter time constants mean the same thing
+// regardless of how long touch processing takes on a given loop iteration.
+#define CONTROL_TICK_US (500)           // 2 kHz (leaves loop headroom for touch)
+#define VELOCITY_TAU_S (0.004f)         // velocity estimate smoothing, seconds
+
+// Remote-movement control gains, in ADC counts (see MODEL notes below).
+// The plant is close to a velocity source with a friction deadband: above a
+// breakaway duty, speed is roughly proportional to duty; below it nothing
+// moves at all. Coast-down is first order with tau ~5 ms, so stopping distance
+// is ~v * 6 ms - which is why arriving at full speed overshoots by ~40 ADC
+// counts no matter how hard the bridge brakes afterwards.
+#define MOVE_KP (2.0f)                  // duty per ADC count of error
+#define MOVE_KD (0.04f)                 // duty per (ADC count/sec) of velocity
+// KD also sets the tolerance to added carriage mass (e.g. a heavier knob cap):
+// drive is cut at v = (KP/KD)*error, and overshoot appears once that ratio
+// approaches 1/tau. At KP/KD = 50/s against a measured 1/tau of ~200/s there is
+// roughly a 2-2.5x margin on effective moving mass before ringing returns.
+// Friction feedforward, per direction. These are deliberately set ABOVE the
+// breakaway duty measured on any one fader (68/88 on the reference unit), and
+// are centred in the range that keeps every move settling rather than tuned for
+// best accuracy on one fader. Rationale: the failure that matters is a fader
+// that never settles and times out, and that happens when FF lands BELOW a
+// unit's breakaway - the carriage then stalls just outside the deadband, waits
+// for the stiction ramp, and escapes with a jump it cannot stop inside the
+// window. Overshooting FF upward is cheap because MOVE_TAKEUP_DUTY caps drive
+// while stalled, so an over-high FF is clamped rather than violent.
+// Measured settling window on the reference fader is FF 66..146 rising; 106 is
+// its centre, giving roughly +/-40 duty counts of breakaway tolerance instead
+// of the +/-10 that a "just under breakaway" value gives. Accuracy is better at
+// the centre too. Do not "optimise" these down against a single fader.
+#define MOVE_FF_RISING (106)            // centred in the stable window
+#define MOVE_FF_FALLING (124)           // same, plus the measured direction offset
+// On-target window. This has a hard floor set by the plant, not by taste:
+// nothing moves below breakaway duty, and at breakaway speed jumps straight to
+// ~900 raw/s, so the smallest correction the fader can make is roughly that
+// speed times the reaction+stopping time - about 10-16 raw, i.e. 5-8 ADC
+// counts. A deadband below that floor cannot be satisfied on a fader whose
+// breakaway differs from the feedforward constants: the controller steps past
+// the window in both directions forever and eventually trips the movement
+// timeout. Keep this at or above the floor; it is ~1.5 LSB of the 8-bit
+// position the host sees, so tightening it buys nothing a host can observe.
+#define MOVE_DEADBAND (6.0f)            // ADC counts considered "on target"
+#define MOVE_MAX_DUTY (254)
+
+// On movement timeout, an error this small means the fader is essentially in
+// position and merely hunting - give up quietly rather than latching
+// MODE_ERROR, which needs a host round-trip to clear. Anything larger is a
+// genuine fault and still errors.
+#define MOVE_TIMEOUT_TOLERANCE (20.0f)  // ADC counts
+
+// Stiction ramp. The feedforward alone leaves a dead region: for small errors
+// FF + KP*error can sit below this unit's actual breakaway duty, so the
+// controller commands motion it cannot produce and the move never completes
+// (previously this timed out into MODE_ERROR). Rather than raise the
+// feedforward - which overshoots on a looser fader, since anything above
+// breakaway jumps straight to ~900 raw counts/sec - ramp in extra drive only
+// while we are asking for motion and not getting it, and drop it the moment
+// the carriage breaks free. This finds whatever breakaway a given fader has
+// instead of relying on a per-unit constant.
+#define MOVE_STALL_VELOCITY (60.0f)     // ADC counts/sec below which we're stalled
+#define MOVE_RAMP_RATE (250.0f)         // duty per second of ramp-in
+#define MOVE_RAMP_MAX (70.0f)           // ceiling, so a jam can't wind up to full drive
+
+// Backlash take-up. There is a little slack in the belt, so a move that
+// reverses direction starts with the motor unloaded. Commanding full duty into
+// that slack lets the rotor spin up freely and then snap taut, which is both an
+// audible click and a jerk at the carriage. While we are still stalled the
+// drive is therefore capped just above breakaway: enough to cross the slack
+// promptly, but slow enough that engagement is gentle. Full authority returns
+// as soon as the carriage is actually moving, so this costs only a few ms.
+#define MOVE_TAKEUP_DUTY (95)           // duty ceiling while stalled (0 = disabled)
+
+#if DEBUG_DRIVE
+// Runtime-tunable copies, so gain sweeps don't need a reflash per trial.
+float move_kp = MOVE_KP;
+float move_kd = MOVE_KD;
+int16_t move_ff_rising = MOVE_FF_RISING;
+int16_t move_ff_falling = MOVE_FF_FALLING;
+float move_deadband = MOVE_DEADBAND;
+float move_ramp_rate = MOVE_RAMP_RATE;
+int16_t move_takeup_duty = MOVE_TAKEUP_DUTY;
+#else
+#define move_kp MOVE_KP
+#define move_kd MOVE_KD
+#define move_ff_rising MOVE_FF_RISING
+#define move_ff_falling MOVE_FF_FALLING
+#define move_deadband MOVE_DEADBAND
+#define move_ramp_rate MOVE_RAMP_RATE
+#define move_takeup_duty MOVE_TAKEUP_DUTY
+#endif
+
 const float ALPHA = 0.05;
 float input_ewma = 0;
-float input_slow_ewma = 0;
+float stiction_ramp = 0;                // extra drive ramped in while stalled
+float velocity_ewma = 0;                // ADC counts/sec, + toward the motor end
+float last_control_ewma = 0;
+uint32_t last_control_tick_us = 0;
+uint32_t last_control_exec_us = 0;
+uint32_t control_dt_us = CONTROL_TICK_US;  // measured interval of the current tick
+#if DEBUG_DRIVE
+uint16_t control_tick_period_us = CONTROL_TICK_US;  // runtime-tunable for sweeps
+#else
+#define control_tick_period_us CONTROL_TICK_US
+#endif
 
 // Touch state
 bool touch = false;
@@ -148,6 +250,40 @@ struct LayerHapticWrite {
 };
 volatile LayerHapticWrite i2c_layer_haptic_write = {0, 0, false};
 
+#if DEBUG_DRIVE
+// ---------------------------------------------------------------------------
+// Open-loop drive register (system identification only; not built into the
+// production firmware). Lets a host command a raw duty/decay/PWM-frequency
+// combination so duty->velocity and friction breakaway can be measured
+// directly instead of inferred from closed-loop behaviour.
+// ---------------------------------------------------------------------------
+#define DEBUG_DRIVE_WATCHDOG_MS (400)  // Auto-coast if the host stops refreshing
+#define DEBUG_DRIVE_EDGE_MARGIN (30)   // ADC counts of endstop keep-out
+
+volatile bool i2c_debug_gain_valid = false;
+volatile uint8_t i2c_debug_gain_index = 0;
+volatile int16_t i2c_debug_gain_value = 0;
+
+volatile bool i2c_debug_drive_valid = false;
+volatile uint8_t i2c_debug_drive_flags = 0;
+volatile uint8_t i2c_debug_drive_duty = 0;
+
+bool debug_drive_active = false;
+int16_t debug_drive_value = 0;
+bool debug_drive_slow_decay = false;
+bool debug_drive_brake = false;
+uint32_t debug_drive_last_update = 0;
+
+// Snapshot of control-loop internals for REG_DEBUG_STATUS
+float debug_status_velocity = 0;
+float debug_status_error = 0;
+uint16_t debug_status_loop_hz = 0;
+uint16_t debug_status_tick_hz = 0;
+uint16_t debug_loop_count = 0;
+uint16_t debug_tick_count = 0;
+uint32_t debug_rate_window_start = 0;
+#endif
+
 uint32_t remote_movement_start = 0;
 uint32_t touch_state_change_millis = 0;
 uint32_t remote_movement_steady_start = 0;
@@ -185,10 +321,10 @@ Mode get_mode() {
 
 void set_mode(Mode mode) {
   state = (state & ~STATE_MODE_bm) | (mode << STATE_MODE_bp);
-  if (mode == MODE_REMOTE_MOVEMENT_IN_PROGRESS || mode == MODE_SELF_CALIBRATION) {
-    TCA0.SPLIT.CTRLA = TCA_SPLIT_ENABLE_bm | TCA_SPLIT_CLKSEL_DIV256_gc;
-  } else {
-    TCA0.SPLIT.CTRLA = TCA_SPLIT_ENABLE_bm | TCA_SPLIT_CLKSEL_DIV4_gc;
+
+  // Any fresh movement starts without accumulated stiction ramp
+  if (mode != MODE_REMOTE_MOVEMENT_IN_PROGRESS) {
+    stiction_ramp = 0;
   }
 
   // Reset tap detection when entering modes where taps shouldn't be detected
@@ -197,7 +333,76 @@ void set_mode(Mode mode) {
   }
 }
 
-// Configure TCA0 for high-frequency PWM so it's not audible via the motor
+// ============================================================================
+// Motor drive
+// ============================================================================
+// PA4 = Motor A (WO4/HCMP1), PA5 = Motor B (WO5/HCMP2). Both feed the DRV8837
+// IN1/IN2 inputs: 1/0 = forward, 0/1 = reverse, 0/0 = coast (Hi-Z), 1/1 = brake.
+#define MOTOR_A_bm (1 << 4)
+#define MOTOR_B_bm (1 << 5)
+
+enum MotorIdle : uint8_t {
+  MOTOR_IDLE_COAST = 0,  // Bridge Hi-Z: fader is free to move
+  MOTOR_IDLE_BRAKE = 1,  // Both low sides on: dynamic braking against motion
+};
+
+int16_t motor_drive_value = 0;  // Last applied signed drive, for status/LED
+
+// Apply a signed motor drive.
+//   drive > 0 pushes toward the motor end (rising ADC), < 0 toward the low end.
+//   |drive| is 0..254, matching the TCA0 split-mode period.
+//
+// slow_decay selects how the off-portion of each PWM cycle is handled:
+//   false (fast decay): PWM alternates drive <-> coast. Winding current decays
+//     through the body diodes each cycle, so at high PWM frequency the average
+//     current is far below what the duty implies and low-duty torque collapses.
+//   true (slow decay): PWM alternates drive <-> brake, keeping current
+//     circulating through the bridge. Average current (and torque) tracks duty
+//     much more linearly, which is what lets us run an inaudible carrier
+//     without losing low-speed authority.
+void motor_set(int16_t drive, bool slow_decay, MotorIdle idle_mode) {
+  if (drive > 254) drive = 254;
+  if (drive < -254) drive = -254;
+  motor_drive_value = drive;
+
+  if (drive == 0) {
+    // Set the static pin levels before releasing the pins from the timer, so
+    // handover can't briefly present a drive combination.
+    if (idle_mode == MOTOR_IDLE_BRAKE) {
+      VPORTA.OUT |= (MOTOR_A_bm | MOTOR_B_bm);
+    } else {
+      VPORTA.OUT &= ~(MOTOR_A_bm | MOTOR_B_bm);
+    }
+    TCA0.SPLIT.CTRLB = 0;
+    return;
+  }
+
+  uint8_t mag = (drive > 0) ? (uint8_t)drive : (uint8_t)(-drive);
+
+  if (!slow_decay) {
+    TCA0.SPLIT.HCMP1 = (drive > 0) ? mag : 0;
+    TCA0.SPLIT.HCMP2 = (drive > 0) ? 0 : mag;
+    TCA0.SPLIT.CTRLB = (TCA_SPLIT_HCMP1EN_bm | TCA_SPLIT_HCMP2EN_bm);
+  } else {
+    // Hold the leading pin high from PORT and PWM the trailing pin between
+    // drive (low) and brake (high), so its high fraction is the inverse duty.
+    if (drive > 0) {
+      VPORTA.OUT |= MOTOR_A_bm;
+      TCA0.SPLIT.HCMP2 = 254 - mag;
+      TCA0.SPLIT.CTRLB = TCA_SPLIT_HCMP2EN_bm;
+    } else {
+      VPORTA.OUT |= MOTOR_B_bm;
+      TCA0.SPLIT.HCMP1 = 254 - mag;
+      TCA0.SPLIT.CTRLB = TCA_SPLIT_HCMP1EN_bm;
+    }
+  }
+}
+
+// Configure TCA0 for a single, permanently inaudible PWM carrier.
+// Movement used to drop to DIV256 (306 Hz) because at 19.6 kHz with drive/coast
+// PWM the motor needed ~190 duty to break away at all. Slow-decay drive (see
+// motor_set) restores low-duty torque at the high carrier, so the audible
+// carrier is no longer needed anywhere.
 void setup_tca0() {
   // TakeOver TCA0 for PWM
   takeOverTCA0();
@@ -213,7 +418,7 @@ void setup_tca0() {
   TCA0.SPLIT.HCMP1 = 0;
   TCA0.SPLIT.HCMP2 = 0;
 
-  TCA0.SPLIT.CTRLA = TCA_SPLIT_ENABLE_bm | TCA_SPLIT_CLKSEL_DIV256_gc;
+  TCA0.SPLIT.CTRLA = TCA_SPLIT_ENABLE_bm | TCA_SPLIT_CLKSEL_DIV4_gc;  // 19.6 kHz
 }
 
 // I2C request handler - called when master requests data
@@ -223,10 +428,13 @@ void onI2cRequest() {
   if (r == REG_VERSION) {
       Wire.write(I2C_PROTOCOL_VERSION);
   } else if (r == REG_STATE) {
-      Wire.write((i2c_outgoing_state >> 24) & 0xFF);
-      Wire.write((i2c_outgoing_state >> 16) & 0xFF);
-      Wire.write((i2c_outgoing_state >> 8) & 0xFF);
-      Wire.write(i2c_outgoing_state & 0xFF);
+      // Snapshot once: the main loop can update i2c_outgoing_state between
+      // byte writes, which would hand the controller a torn value.
+      uint32_t s = i2c_outgoing_state;
+      Wire.write((s >> 24) & 0xFF);
+      Wire.write((s >> 16) & 0xFF);
+      Wire.write((s >> 8) & 0xFF);
+      Wire.write(s & 0xFF);
   } else if (r == REG_UPTIME) {
       uint32_t uptime = millis();
       Wire.write((uptime >> 24) & 0xFF);
@@ -263,6 +471,20 @@ void onI2cRequest() {
       // Touch recalibration count (unsigned 16-bit)
       Wire.write((touch_recal_count >> 8) & 0xFF);  // High byte
       Wire.write(touch_recal_count & 0xFF);         // Low byte
+#if DEBUG_DRIVE
+  } else if (r == REG_DEBUG_STATUS) {
+      int16_t vel = (int16_t)debug_status_velocity;
+      int16_t err_x8 = (int16_t)(debug_status_error * 8);
+      const uint16_t vals[8] = {
+        input_calib_min, input_calib_max, (uint16_t)target_adc,
+        (uint16_t)motor_drive_value, (uint16_t)vel, (uint16_t)err_x8,
+        debug_status_loop_hz, debug_status_tick_hz,
+      };
+      for (uint8_t i = 0; i < 8; i++) {
+        Wire.write((vals[i] >> 8) & 0xFF);
+        Wire.write(vals[i] & 0xFF);
+      }
+#endif
   } else if (r == REG_ACTIVE_LAYER) {
       Wire.write(active_layer);
   } else if (r == REG_LAYER_TARGET) {
@@ -326,6 +548,22 @@ void onI2cReceive(int howMany) {
         i2c_layer_haptic_write.valid = true;
       }
       break;
+#if DEBUG_DRIVE
+    case REG_DEBUG_GAINS:
+      if (howMany == 4) {
+        i2c_debug_gain_index = Wire.read();
+        i2c_debug_gain_value = (int16_t)(((uint16_t)Wire.read() << 8) | Wire.read());
+        i2c_debug_gain_valid = true;
+      }
+      break;
+    case REG_DEBUG_DRIVE:
+      if (howMany == 3) {
+        i2c_debug_drive_flags = Wire.read();
+        i2c_debug_drive_duty = Wire.read();
+        i2c_debug_drive_valid = true;
+      }
+      break;
+#endif
     case REG_VERSION:
     case REG_STATE:
     case REG_UPTIME:
@@ -557,11 +795,52 @@ void write_layer_haptic_config(uint8_t layer, uint16_t config) {
   }
 }
 
+// Fold every completed free-running ADC1 conversion into the position filter.
+// Draining on the RESRDY flag rather than sampling RES whenever the main loop
+// happens to come around means the filter runs at the ADC's own constant rate
+// and never re-uses or tears a result.
+uint16_t adc_last_raw = 0;
+void adc_drain() {
+  while (ADC1.INTFLAGS & ADC_RESRDY_bm) {
+    uint16_t adc_val = ADC1.RES;  // reading RES clears RESRDY
+    adc_last_raw = adc_val;
+    // 2x accumulation, so halve to get ADC counts
+    input_ewma = adc_val * ALPHA / 2 + input_ewma * (1 - ALPHA);
+  }
+}
+
 void motor_update() {
   uint32_t now = millis();
 
-  uint16_t adc_val = ADC1.RES;
-  input_ewma = adc_val * ALPHA / 2 + input_ewma * (1-ALPHA); // Use free-running ADC1 result; (2x aggregation, so divide by 2)
+  uint16_t adc_val = adc_last_raw;
+
+  // Velocity for the damping term: differentiate the filtered position, then
+  // smooth with a fixed time constant. Dividing by the measured interval
+  // rather than the nominal tick keeps the estimate correct even when a tick
+  // lands late, and input_ewma is a float fed by a dithered ADC, so its
+  // differences stay meaningful well below one ADC count.
+  float dt = control_dt_us * 1e-6f;
+  if (dt > 0.0f) {
+    float dv = (input_ewma - last_control_ewma) / dt;
+    float alpha_v = dt / VELOCITY_TAU_S;
+    if (alpha_v > 1.0f) alpha_v = 1.0f;
+    velocity_ewma += alpha_v * (dv - velocity_ewma);
+  }
+  last_control_ewma = input_ewma;
+
+#if DEBUG_DRIVE
+  debug_status_velocity = velocity_ewma;
+  debug_status_error = target_adc - input_ewma;
+  debug_tick_count++;
+  if (now - debug_rate_window_start >= 500) {
+    debug_status_loop_hz = debug_loop_count * 2;
+    debug_status_tick_hz = debug_tick_count * 2;
+    debug_loop_count = 0;
+    debug_tick_count = 0;
+    debug_rate_window_start = now;
+  }
+#endif
+
   Mode mode = get_mode();
 
   // If we didn't get a second tap start in time, reset tap detection
@@ -587,10 +866,38 @@ void motor_update() {
     position = position_window_lower;
   }
 
+#if DEBUG_DRIVE
+  if (debug_drive_active) {
+    int16_t d = debug_drive_value;
+    if (now - debug_drive_last_update > DEBUG_DRIVE_WATCHDOG_MS) {
+      // Host stopped refreshing - never leave the motor driven unattended
+      debug_drive_active = false;
+      d = 0;
+    } else if ((d > 0 && input_ewma > input_calib_max - DEBUG_DRIVE_EDGE_MARGIN) ||
+               (d < 0 && input_ewma < input_calib_min + DEBUG_DRIVE_EDGE_MARGIN)) {
+      // Don't drive into the endstops
+      d = 0;
+    }
+    motor_set(d, debug_drive_slow_decay,
+              debug_drive_brake ? MOTOR_IDLE_BRAKE : MOTOR_IDLE_COAST);
+  } else
+#endif
   switch (mode) {
     case MODE_REMOTE_MOVEMENT_IN_PROGRESS:
       if (now > remote_movement_start + MOVEMENT_TIMEOUT_MILLIS) {
-        set_mode(Mode::MODE_ERROR);
+        // Distinguish a real fault (jam, dead motor, unreachable target) from a
+        // fader that arrived but kept dithering across the deadband. The latter
+        // is a tuning mismatch, not a failure, and reporting it as an error
+        // leaves the fader dead until the host clears it.
+        float timeout_error = target_adc - input_ewma;
+        if (timeout_error < 0) timeout_error = -timeout_error;
+        if (timeout_error <= MOVE_TIMEOUT_TOLERANCE) {
+          motor_set(0, false, MOTOR_IDLE_COAST);
+          input_last_change_millis = now - IDLE_DURATION_THRESHOLD;
+          set_mode(Mode::MODE_INPUT_IDLE);
+        } else {
+          set_mode(Mode::MODE_ERROR);
+        }
       } else if ((state & STATE_TOUCH_bm) && now > touch_state_change_millis + TOUCH_OVERRIDE_DURATION_THRESHOLD) {
         set_mode(Mode::MODE_INPUT_ACTIVE);
       } else {
@@ -599,20 +906,46 @@ void motor_update() {
           apply_layer_change(pending_layer_change);
           break;  // Exit switch since state may change
         }
-        float delta = (target_adc - input_ewma) * 1.2;
-        if (delta > 4) {
-          uint8_t pwm = delta + 80 > 254 ? 254 : delta + 80;
-          TCA0.SPLIT.HCMP1 = pwm;  // Motor A
-          TCA0.SPLIT.HCMP2 = 0;    // Motor B
-          remote_movement_steady_start = now;
-        } else if (delta < -4) {
-          uint8_t pwm = -delta + 80 > 254 ? 254 : -delta + 80;
-          TCA0.SPLIT.HCMP1 = 0;    // Motor A
-          TCA0.SPLIT.HCMP2 = pwm;  // Motor B
+        float error = target_adc - input_ewma;
+        if (error > move_deadband || error < -move_deadband) {
+          // PD on position plus a friction feedforward sized just under the
+          // measured breakaway duty, so the controller only has to supply the
+          // part of the drive that sets speed rather than fighting stiction.
+          // The D term is what prevents overshoot: it cancels the feedforward
+          // while the carriage is still moving fast, cutting drive roughly one
+          // stopping distance short of the target so it coasts in.
+          float u = move_kp * error - move_kd * velocity_ewma;
+          u += (error > 0) ? move_ff_rising : -move_ff_falling;
+
+          // Ramp in extra drive only while stalled, and shed it as soon as the
+          // carriage moves, so the ramp never contributes to overshoot.
+          float speed = velocity_ewma < 0 ? -velocity_ewma : velocity_ewma;
+          if (speed < MOVE_STALL_VELOCITY) {
+            stiction_ramp += move_ramp_rate * (control_dt_us * 1e-6f);
+            if (stiction_ramp > MOVE_RAMP_MAX) stiction_ramp = MOVE_RAMP_MAX;
+          } else {
+            stiction_ramp = 0;
+          }
+          u += (error > 0) ? stiction_ramp : -stiction_ramp;
+
+          // Cap drive until the carriage is moving, so the motor eases through
+          // belt backlash instead of snapping it taut at full duty.
+          int16_t limit = MOVE_MAX_DUTY;
+          if (move_takeup_duty > 0 && speed < MOVE_STALL_VELOCITY) {
+            limit = move_takeup_duty + (int16_t)stiction_ramp;
+            if (limit > MOVE_MAX_DUTY) limit = MOVE_MAX_DUTY;
+          }
+
+          int16_t drive = (int16_t)u;
+          if (drive > limit) drive = limit;
+          if (drive < -limit) drive = -limit;
+          motor_set(drive, true, MOTOR_IDLE_BRAKE);
           remote_movement_steady_start = now;
         } else {
-          TCA0.SPLIT.HCMP1 = 0;    // Motor A
-          TCA0.SPLIT.HCMP2 = 0;    // Motor B
+          // On target: hold with the bridge braked until we declare the move
+          // finished, so a loose carriage can't drift back out of the window.
+          stiction_ramp = 0;
+          motor_set(0, true, MOTOR_IDLE_BRAKE);
           if (now > remote_movement_steady_start + REMOTE_MOVEMENT_STEADY_THRESHOLD) {
             // shift hysteresis window to prevent spurious immediate "input" detection if remote movement left us near the window bounds and succeptiple to noise
             if (input_ewma < WINDOW_SIZE / 2) {
@@ -639,8 +972,7 @@ void motor_update() {
       }
 
       if (now > input_last_change_millis + IDLE_DURATION_THRESHOLD && (state & STATE_TOUCH_bm) == 0 && now > touch_state_change_millis + IDLE_DURATION_THRESHOLD) {
-        TCA0.SPLIT.HCMP1 = 0;    // Motor A
-        TCA0.SPLIT.HCMP2 = 0;    // Motor B
+        motor_set(0, false, MOTOR_IDLE_COAST);
         if (pending_report_on_idle) {
           pending_report_on_idle = false;
           increment_position_nonce();
@@ -658,16 +990,13 @@ void motor_update() {
           if (input_ewma < input_calib_min + HAPTIC_MAGNET_RANGE && input_ewma > input_calib_min + HAPTIC_DEAD_ZONE) {
             float delta = (input_calib_min - input_ewma) * HAPTIC_BASE_MULTIPLIER;
             uint8_t pwm = (-delta + HAPTIC_BASE_PWM > max_pwm) ? max_pwm : -delta + HAPTIC_BASE_PWM;
-            TCA0.SPLIT.HCMP1 = 0;    // Motor A
-            TCA0.SPLIT.HCMP2 = pwm;  // Motor B
+            motor_set(-(int16_t)pwm, false, MOTOR_IDLE_COAST);
           } else if (input_ewma > input_calib_max - HAPTIC_MAGNET_RANGE && input_ewma < input_calib_max - HAPTIC_DEAD_ZONE) {
             float delta = (input_calib_max - input_ewma) * HAPTIC_BASE_MULTIPLIER;
             uint8_t pwm = (delta + HAPTIC_BASE_PWM > max_pwm) ? max_pwm : delta + HAPTIC_BASE_PWM;
-            TCA0.SPLIT.HCMP1 = pwm;  // Motor A
-            TCA0.SPLIT.HCMP2 = 0;    // Motor B
+            motor_set((int16_t)pwm, false, MOTOR_IDLE_COAST);
           } else {
-            TCA0.SPLIT.HCMP1 = 0;    // Motor A
-            TCA0.SPLIT.HCMP2 = 0;    // Motor B
+            motor_set(0, false, MOTOR_IDLE_COAST);
           }
         } else if (haptic_mode == HAPTIC_DETENTS) {
           // Detent haptics - pull toward nearest detent position
@@ -689,29 +1018,24 @@ void motor_update() {
             if (delta > 0) {
               // Pull toward higher position (Motor A)
               uint8_t pwm = (delta + HAPTIC_BASE_PWM > max_pwm) ? max_pwm : delta + HAPTIC_BASE_PWM;
-              TCA0.SPLIT.HCMP1 = pwm;  // Motor A
-              TCA0.SPLIT.HCMP2 = 0;    // Motor B
+              motor_set((int16_t)pwm, false, MOTOR_IDLE_COAST);
             } else {
               // Pull toward lower position (Motor B)
               uint8_t pwm = (-delta + HAPTIC_BASE_PWM > max_pwm) ? max_pwm : -delta + HAPTIC_BASE_PWM;
-              TCA0.SPLIT.HCMP1 = 0;    // Motor A
-              TCA0.SPLIT.HCMP2 = pwm;  // Motor B
+              motor_set(-(int16_t)pwm, false, MOTOR_IDLE_COAST);
             }
           } else {
             // Within dead zone, no force
-            TCA0.SPLIT.HCMP1 = 0;    // Motor A
-            TCA0.SPLIT.HCMP2 = 0;    // Motor B
+            motor_set(0, false, MOTOR_IDLE_COAST);
           }
         } else {
           // No haptics for NO_HAPTICS mode
-          TCA0.SPLIT.HCMP1 = 0;    // Motor A
-          TCA0.SPLIT.HCMP2 = 0;    // Motor B
+          motor_set(0, false, MOTOR_IDLE_COAST);
         }
       }
       break;
     case MODE_INPUT_IDLE:
-      TCA0.SPLIT.HCMP1 = 0;    // Motor A
-      TCA0.SPLIT.HCMP2 = 0;    // Motor B
+      motor_set(0, false, MOTOR_IDLE_COAST);
 
       // Apply pending layer change
       if (pending_layer_change != 0xFF) {
@@ -724,8 +1048,7 @@ void motor_update() {
       }
       break;
     case MODE_ERROR:
-      TCA0.SPLIT.HCMP1 = 0;    // Motor A
-      TCA0.SPLIT.HCMP2 = 0;    // Motor B
+      motor_set(0, false, MOTOR_IDLE_COAST);
       break;
     case MODE_SELF_CALIBRATION:
       switch (self_calibration_stage) {
@@ -736,8 +1059,7 @@ void motor_update() {
             self_calibration_start = millis();
           } else {
             // Move toward lower ADC value
-            TCA0.SPLIT.HCMP1 = 0;    // Motor A
-            TCA0.SPLIT.HCMP2 = 254;    // Motor B
+            motor_set(-254, true, MOTOR_IDLE_COAST);
           }
           break;
         case 1:
@@ -747,13 +1069,11 @@ void motor_update() {
             self_calibration_start = millis();
           } else {
             // Move toward higher ADC value
-            TCA0.SPLIT.HCMP1 = 254;    // Motor A
-            TCA0.SPLIT.HCMP2 = 0;    // Motor B
+            motor_set(254, true, MOTOR_IDLE_COAST);
           }
           break;
         case 2:
-          TCA0.SPLIT.HCMP1 = 0;    // Motor A
-          TCA0.SPLIT.HCMP2 = 0;    // Motor B
+          motor_set(0, false, MOTOR_IDLE_COAST);
           if (abs((int16_t)self_calibration_adc_stage_0 - self_calibration_adc_stage_1) < 900) {
             set_mode(Mode::MODE_ERROR);
           } else {
@@ -870,6 +1190,15 @@ void setup() {
   ADC1.CTRLA=ADC_ENABLE_bm|ADC_FREERUN_bm; //start in freerun
   ADC1.COMMAND=ADC_STCONV_bm; //start first conversion!
 
+  // Prime the position filter from a real conversion, so the first control
+  // tick doesn't see a huge phantom velocity as the filter slews up from zero.
+  while (!(ADC1.INTFLAGS & ADC_RESRDY_bm)) { }
+  adc_last_raw = ADC1.RES;
+  input_ewma = adc_last_raw / 2.0f;
+  last_control_ewma = input_ewma;
+  last_control_tick_us = micros();
+  last_control_exec_us = last_control_tick_us;
+
   setup_touch();
   pending_calibrate_touch = true;
 }
@@ -887,6 +1216,14 @@ void process_i2c_requests() {
   bool has_layer_haptic = false;
   uint8_t layer_haptic_layer = 0;
   uint16_t layer_haptic_config = 0;
+#if DEBUG_DRIVE
+  bool has_debug_gain = false;
+  uint8_t debug_gain_index = 0;
+  int16_t debug_gain_value = 0;
+  bool has_debug_drive = false;
+  uint8_t debug_drive_flags = 0;
+  uint8_t debug_drive_duty = 0;
+#endif
 
   // Atomically copy all i2c requests in a single critical section
   noInterrupts();
@@ -906,6 +1243,21 @@ void process_i2c_requests() {
     layer_target_target = i2c_layer_target_write.target;
     i2c_layer_target_write.valid = false;
   }
+
+#if DEBUG_DRIVE
+  if (i2c_debug_gain_valid) {
+    has_debug_gain = true;
+    debug_gain_index = i2c_debug_gain_index;
+    debug_gain_value = i2c_debug_gain_value;
+    i2c_debug_gain_valid = false;
+  }
+  if (i2c_debug_drive_valid) {
+    has_debug_drive = true;
+    debug_drive_flags = i2c_debug_drive_flags;
+    debug_drive_duty = i2c_debug_drive_duty;
+    i2c_debug_drive_valid = false;
+  }
+#endif
 
   if (i2c_layer_haptic_write.valid) {
     has_layer_haptic = true;
@@ -942,6 +1294,58 @@ void process_i2c_requests() {
   if (has_layer_haptic) {
     write_layer_haptic_config(layer_haptic_layer, layer_haptic_config);
   }
+
+#if DEBUG_DRIVE
+  if (has_debug_gain) {
+    switch (debug_gain_index) {
+      case DEBUG_GAIN_KP:         move_kp = debug_gain_value / 1000.0f; break;
+      case DEBUG_GAIN_KD:         move_kd = debug_gain_value / 1000.0f; break;
+      case DEBUG_GAIN_FF_RISING:  move_ff_rising = debug_gain_value; break;
+      case DEBUG_GAIN_FF_FALLING: move_ff_falling = debug_gain_value; break;
+      case DEBUG_GAIN_DEADBAND:   move_deadband = debug_gain_value / 1000.0f; break;
+      case DEBUG_GAIN_RAMP_RATE:  move_ramp_rate = debug_gain_value; break;
+      case DEBUG_GAIN_TAKEUP:     move_takeup_duty = debug_gain_value; break;
+      // Override the calibration bounds (RAM only, not persisted) so a
+      // miscalibrated fader - one whose stored range exceeds its physical
+      // travel - can be reproduced on a good unit.
+      case DEBUG_GAIN_CALIB_MIN:  input_calib_min = debug_gain_value; break;
+      case DEBUG_GAIN_CALIB_MAX:  input_calib_max = debug_gain_value; break;
+      case DEBUG_GAIN_TICK_US:
+        if (debug_gain_value >= 100 && debug_gain_value <= 5000) {
+          control_tick_period_us = debug_gain_value;
+        }
+        break;
+    }
+  }
+
+  if (has_debug_drive) {
+    if (debug_drive_flags == DEBUG_DRIVE_FLAGS_EXIT) {
+      debug_drive_active = false;
+      debug_drive_value = 0;
+      motor_set(0, false, MOTOR_IDLE_COAST);
+      // Hand both pins back to the timer, since the closed-loop paths drive
+      // HCMPn directly and assume both compare outputs stay enabled.
+      TCA0.SPLIT.CTRLB = (TCA_SPLIT_HCMP1EN_bm | TCA_SPLIT_HCMP2EN_bm);
+      set_mode(MODE_INPUT_IDLE);
+    } else {
+      uint8_t dir = debug_drive_flags & DEBUG_DRIVE_DIR_bm;
+      debug_drive_slow_decay = (debug_drive_flags & DEBUG_DRIVE_SLOW_DECAY_bm) != 0;
+      debug_drive_value = (dir == DEBUG_DRIVE_DIR_A) ? (int16_t)debug_drive_duty
+                        : (dir == DEBUG_DRIVE_DIR_B) ? -(int16_t)debug_drive_duty
+                        : 0;
+      debug_drive_brake = (dir == DEBUG_DRIVE_DIR_BRAKE);
+      // PWM prescaler select, so fast/slow decay can be compared at each carrier
+      uint8_t clk = (debug_drive_flags & DEBUG_DRIVE_CLK_bm) >> DEBUG_DRIVE_CLK_bp;
+      uint8_t clksel = (clk == 0) ? TCA_SPLIT_CLKSEL_DIV4_gc
+                     : (clk == 1) ? TCA_SPLIT_CLKSEL_DIV256_gc
+                     : (clk == 2) ? TCA_SPLIT_CLKSEL_DIV2_gc
+                                  : TCA_SPLIT_CLKSEL_DIV8_gc;
+      TCA0.SPLIT.CTRLA = TCA_SPLIT_ENABLE_bm | clksel;
+      debug_drive_active = true;
+      debug_drive_last_update = millis();
+    }
+  }
+#endif
 }
 
 void loop() {
@@ -950,8 +1354,7 @@ void loop() {
 
   if (pending_calibrate_touch) {
     pending_calibrate_touch = false;
-    TCA0.SPLIT.HCMP1 = 0;    // Motor A
-    TCA0.SPLIT.HCMP2 = 0;    // Motor B
+    motor_set(0, false, MOTOR_IDLE_COAST);
     delay(10);
     ptc_node_request_recal(&touch_sensor);
     // for (uint8_t i = 0; i < 4; i++) {
@@ -961,17 +1364,39 @@ void loop() {
     //   delay(100);
     // }
   }
-  motor_update();
+  // Keep the position filter fed from the free-running ADC on every pass, but
+  // run the control law on a fixed tick so gains and filter constants have
+  // real units instead of being per-loop-iteration.
+  adc_drain();
+#if DEBUG_DRIVE
+  debug_loop_count++;
+#endif
 
-  // Copy state to i2c_outgoing_state atomically for ISR reads
-  noInterrupts();
-  i2c_outgoing_state = state;
-  interrupts();
+  uint32_t now_us = micros();
+  if (now_us - last_control_tick_us >= control_tick_period_us) {
+    // dt must be the interval since the previous *execution*, not since the
+    // scheduled tick time: when the loop can't keep up, the schedule falls
+    // behind real time and using it would skew the velocity estimate.
+    control_dt_us = now_us - last_control_exec_us;
+    last_control_exec_us = now_us;
+    last_control_tick_us += control_tick_period_us;
+    // If we fell far behind (e.g. a long blocking call), resynchronise rather
+    // than running a burst of catch-up ticks.
+    if (now_us - last_control_tick_us >= (uint32_t)control_tick_period_us * 4) {
+      last_control_tick_us = now_us;
+    }
+    motor_update();
+
+    // Copy state to i2c_outgoing_state atomically for ISR reads
+    noInterrupts();
+    i2c_outgoing_state = state;
+    interrupts();
+  }
 
   ptc_process(millis());
 
   // digitalWrite(PIN_LED, (state & STATE_TOUCH_bm) >> STATE_TOUCH_bp);
-  digitalWrite(PIN_LED, (TCA0.SPLIT.HCMP1 != 0 || TCA0.SPLIT.HCMP2 != 0) || (millis() % 512 < 128));
+  digitalWrite(PIN_LED, (motor_drive_value != 0) || (millis() % 512 < 128));
   // digitalWrite(PIN_LED, millis()%512 < 128 || touch);
 
 }

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -14,9 +14,9 @@
  */
 
 #include <Arduino.h>
+#include <util/delay.h>
 #include <Wire.h>
 #include <ptc_touch.h>
-#include <megaTinyCore.h>
 #include <EEPROM.h>
 
 #include "shared/i2c_data.h"
@@ -27,8 +27,10 @@
 #define DEMO 0
 
 #define PIN_LED (PIN_PB2)
+#define LED_bm (1 << 2)  // PIN_LED on VPORTB, for direct port access
 
 #define PIN_MOTOR_nSLEEP (PIN_PB3)
+#define MOTOR_nSLEEP_bm (1 << 3)  // PIN_MOTOR_nSLEEP on VPORTB, for direct port access
 
 // Energizing pin A moves fader toward the motor end
 #define PIN_MOTOR_A (PIN_PA4)
@@ -86,27 +88,45 @@ enum TapState : uint8_t {
 // moves at all. Coast-down is first order with tau ~5 ms, so stopping distance
 // is ~v * 6 ms - which is why arriving at full speed overshoots by ~40 ADC
 // counts no matter how hard the bridge brakes afterwards.
-#define MOVE_KP (2.0f)                  // duty per ADC count of error
-#define MOVE_KD (0.04f)                 // duty per (ADC count/sec) of velocity
-// KD also sets the tolerance to added carriage mass (e.g. a heavier knob cap):
-// drive is cut at v = (KP/KD)*error, and overshoot appears once that ratio
-// approaches 1/tau. At KP/KD = 50/s against a measured 1/tau of ~200/s there is
-// roughly a 2-2.5x margin on effective moving mass before ringing returns.
-// Friction feedforward, per direction. These are deliberately set ABOVE the
-// breakaway duty measured on any one fader (68/88 on the reference unit), and
-// are centred in the range that keeps every move settling rather than tuned for
-// best accuracy on one fader. Rationale: the failure that matters is a fader
-// that never settles and times out, and that happens when FF lands BELOW a
-// unit's breakaway - the carriage then stalls just outside the deadband, waits
-// for the stiction ramp, and escapes with a jump it cannot stop inside the
-// window. Overshooting FF upward is cheap because MOVE_TAKEUP_DUTY caps drive
-// while stalled, so an over-high FF is clamped rather than violent.
-// Measured settling window on the reference fader is FF 66..146 rising; 106 is
-// its centre, giving roughly +/-40 duty counts of breakaway tolerance instead
-// of the +/-10 that a "just under breakaway" value gives. Accuracy is better at
-// the centre too. Do not "optimise" these down against a single fader.
-#define MOVE_FF_RISING (106)            // centred in the stable window
-#define MOVE_FF_FALLING (124)           // same, plus the measured direction offset
+// The law is a cascade: the position loop sets a velocity reference, and the
+// velocity loop realises it. The old flat form (u = KP*e - KD*v + FF) was
+// already this - it factors exactly as FF + KD*((KP/KD)*e - v) - but written
+// flat it hid two things worth seeing:
+//
+//  - the inner loop's open-loop gain is k*KV, where k is the plant's ADC/s per
+//    duty. That, not KV alone, is what sets damping, so a higher-torque motor
+//    is a more aggressive loop. Through the lag of the velocity estimate it
+//    goes underdamped and the fader oscillates on velocity - overshoot, brake,
+//    re-accelerate. KV is therefore scaled by 1/k on a characterised unit.
+//  - the speed limit belongs on the reference, not bolted on as a governor
+//    that subtracts drive once the fader is already too fast.
+//
+// MOVE_VREF_SLOPE is the old KP/KD ratio and keeps its meaning: drive is cut
+// when the carriage is faster than slope*error, so the controller coasts the
+// last stretch. At 50/s against a measured 1/tau of ~200/s it cuts about four
+// stopping distances short, which also leaves roughly 2-2.5x margin on
+// effective moving mass (a heavier knob cap) before ringing returns.
+#define MOVE_VREF_SLOPE (50.0f)         // ADC counts/sec of reference per ADC count of error
+#define MOVE_KV (0.04f)                 // duty per (ADC count/sec) of velocity error
+// Friction feedforward. The plant needs `breakaway` duty before it moves at
+// all, then gains `k` ADC counts/sec of speed per further duty count, so the
+// drive that produces a wanted speed is exactly
+//
+//     u_ff = breakaway + v_ref / k
+//
+// Expressing it this way rather than as one fixed number is what lets the
+// speed limit be honoured: a fixed feedforward commands whatever speed it
+// commands (~1100 ADC/s on the reference unit) and nothing below that is
+// reachable without subtracting drive back off again - which is what the old
+// one-sided governor did, and why it limit-cycled.
+//
+// The defaults below are the reference unit's plant, implied by the previous
+// fixed feedforward: FF 106/124 at k 29 is breakaway 68/86 plus 38 duty, and
+// 38 duty at k 29 is 1100 ADC/s. A characterised unit measures all of this.
+#define MOVE_BD_RISING (68)             // assumed breakaway duty, rising ADC
+#define MOVE_BD_FALLING (86)            // assumed breakaway duty, falling ADC
+#define MOVE_K_DEFAULT (29)             // assumed ADC counts/sec per duty count
+#define MOVE_VJUMP_DEFAULT (448)        // assumed Stribeck jump; 1.25x it is MOVE_VEL_MIN
 // On-target window. This has a hard floor set by the plant, not by taste:
 // nothing moves below breakaway duty, and at breakaway speed jumps straight to
 // ~900 raw/s, so the smallest correction the fader can make is roughly that
@@ -116,7 +136,7 @@ enum TapState : uint8_t {
 // the window in both directions forever and eventually trips the movement
 // timeout. Keep this at or above the floor; it is ~1.5 LSB of the 8-bit
 // position the host sees, so tightening it buys nothing a host can observe.
-#define MOVE_DEADBAND (6.0f)            // ADC counts considered "on target"
+#define MOVE_DEADBAND (8.0f)            // ADC counts considered "on target"
 #define MOVE_MAX_DUTY (254)
 
 // Optional speed limiting. Cruise velocity is already proportional to error
@@ -144,14 +164,13 @@ enum TapState : uint8_t {
 //  - the governor pulls drive below the feedforward. The feedforward alone
 //    commands ~2200 raw counts/sec, so clamping the error can only slow the
 //    fader to that floor, never under it.
-#define MOVE_VELOCITY_PER_ERROR (30.0f)  // ADC counts/sec per ADC count of error
-#define MOVE_VEL_LIMIT_GAIN (0.08f)      // duty per (ADC count/sec) of overspeed
-// Slowest speed the mechanism sustains smoothly. Below roughly this the motor
-// cannot maintain continuous rotation (Stribeck friction) and creeps in
-// stick-slip steps instead, so requests slower than this are clamped rather
-// than honoured. Measured floor is ~150 position counts/sec, i.e. full travel
-// in about 1.7 s.
-#define MOVE_VEL_MIN (560.0f)            // ADC counts/sec
+// Slowest speed the mechanism sustains smoothly, and therefore the floor the
+// velocity reference is held at even right next to the target. Below roughly
+// this the motor cannot maintain continuous rotation (Stribeck friction) and
+// creeps in stick-slip steps instead. It doubles as the guarantee that the
+// feedforward stays clear of breakaway: the drive never falls below
+// breakaway + MOVE_VEL_MIN/k, so small errors still command real motion.
+#define MOVE_VEL_MIN (560)            // ADC counts/sec
 #define MOVE_VEL_UNLIMITED (0.0f)
 
 // Endpoints of the host-facing unitless speed scale (LAYER_SPEED_SLOWEST ..
@@ -162,8 +181,8 @@ enum TapState : uint8_t {
 // what the unlimited controller already does, so it stops having any effect.
 // Mapping the whole byte onto this window means every value a host can send
 // does something, rather than most of the range being unusable.
-#define MOVE_SPEED_SLOWEST_MS (700.0f)
-#define MOVE_SPEED_FASTEST_MS (250.0f)
+#define MOVE_SPEED_SLOWEST_MS (700)
+#define MOVE_SPEED_FASTEST_MS (250)
 
 // On movement timeout, an error this small means the fader is essentially in
 // position and merely hunting - give up quietly rather than latching
@@ -183,6 +202,7 @@ enum TapState : uint8_t {
 #define MOVE_STALL_VELOCITY (60.0f)     // ADC counts/sec below which we're stalled
 #define MOVE_RAMP_RATE (250.0f)         // duty per second of ramp-in
 #define MOVE_RAMP_MAX (70.0f)           // ceiling, so a jam can't wind up to full drive
+#define MOVE_RAMP_DECAY_RATE (3500.0f)  // duty/sec shed once moving (~20 ms from full)
 
 // Backlash take-up. There is a little slack in the belt, so a move that
 // reverses direction starts with the motor unloaded. Commanding full duty into
@@ -209,24 +229,125 @@ enum TapState : uint8_t {
 #define MOVE_TAKEUP_DUTY (130)           // duty ceiling at the start of a move
 #define MOVE_TAKEUP_RAMP_RATE (1200.0f)  // duty per second the ceiling opens up
 
+// ---------------------------------------------------------------------------
+// Per-unit motor characterisation
+// ---------------------------------------------------------------------------
+// Self-calibration measures three things about this specific motor, in each
+// direction, and the gains above are re-derived from them:
+//
+//   breakaway  the duty at which the carriage first moves at all
+//   k          ADC counts/sec of cruise gained per duty count above breakaway
+//   v_jump     the speed motion starts at the instant breakaway is crossed
+//
+// Why this is worth doing rather than picking better constants: the smallest
+// correction the controller can command near the target is roughly
+//
+//   v_min = k * (KP*deadband + FF - breakaway) / (1 + k*KD)
+//
+// and it can only settle if v_min * (stopping time) fits inside the deadband.
+// FF is a fixed duty, so on a unit whose breakaway is well BELOW the value FF
+// was centred on, (FF - breakaway) is large, v_min is high, and the carriage
+// physically cannot land inside the window - it steps past in both directions
+// until the movement timeout. That is the low-stiction failure, and it is the
+// mirror image of the high-stiction one the stiction ramp already handles.
+// Measuring breakaway makes (FF - breakaway) a designed quantity rather than
+// an accident of which fader is fitted.
+//
+// k is what turns a wanted speed into a duty, so it appears twice in the
+// control law: in the feedforward (breakaway + v_ref/k) and in the velocity
+// loop gain, which is scaled by 1/k so the loop's open-loop gain k*KV - the
+// thing that actually sets damping - is the same on every unit.
+
+// Target open-loop gain for the velocity loop, k*KV, held constant across
+// units by scaling KV with 1/k. 1.16 is what the reference unit ran at
+// (k 29, KV 0.04) and settles cleanly; higher rings through the lag of the
+// velocity estimate, lower is sluggish and lets the feedforward's own error
+// show up as steady-state speed droop.
+#define MOTORCAL_KV_LOOP_GAIN (1.16f)
+
+// Floor and ceiling on the derived reference floor (1.25x the Stribeck jump).
+#define MOTORCAL_VEL_MIN_LO (200)
+#define MOTORCAL_VEL_MIN_HI (1500)
+
+// How long it takes to actually stop, measured from the carriage reaching the
+// window rather than from drive being cut. This is NOT the coast time alone:
+// the position filter and the control tick both have to notice first, and the
+// carriage keeps travelling throughout. Coast-down is first order with tau
+// ~5 ms (so ~6 ms of travel), but the reference unit's measured minimum
+// correction of 5-8 ADC counts at 450-560 ADC/s implies 9-18 ms end to end.
+//
+// Getting this wrong is the expensive direction: too small a deadband cannot
+// be satisfied at all, so the fader steps past the window in both directions
+// indefinitely and dithers until the movement timeout. Too large just means a
+// slightly less accurate final position, which is worth well under an LSB of
+// what the host can see. Size it for the pessimistic end.
+#define MOTORCAL_STOP_TIME_MS (15)       // reaction + detection + coast, ms
+#define MOTORCAL_TAKEUP_MARGIN (20)      // take-up ceiling sits this far above FF
+// Bounds on the derived on-target window. The floor is the reference unit's
+// validated value; the ceiling is a backstop against an implausible v_jump
+// measurement, not a judgement that a wider window would be wrong.
+#define MOTORCAL_DEADBAND_LO (8)         // ADC counts
+#define MOTORCAL_DEADBAND_HI (20)
+
+// Measurement procedure. Each run parks at one end, ramps duty until motion
+// starts, then dwells at two fixed duties above breakaway to get a two-point
+// fit for k. Runs alternate direction, so each one starts where the previous
+// one left off and only the first needs a long park.
+#define MOTORCAL_PASSES (2)              // runs per direction, averaged
+// Ramp rate trades calibration time against breakaway resolution. Detection
+// latency is set by the velocity filter (~5 ms), not by the ramp, so 80 duty/s
+// still resolves breakaway to well under a duty count while keeping a full
+// calibration under ~10 s.
+#define MOTORCAL_RAMP_RATE (80.0f)       // duty/sec
+#define MOTORCAL_RAMP_MAX (200.0f)       // give up: this unit has no usable breakaway
+#define MOTORCAL_MOTION_VEL (200.0f)     // ADC counts/sec that counts as "moving"
+#define MOTORCAL_JUMP_MS (40)            // window for capturing the Stribeck jump
+#define MOTORCAL_DWELL_A (25)            // duty above breakaway, first fit point
+#define MOTORCAL_DWELL_B (50)            // duty above breakaway, second fit point
+#define MOTORCAL_DWELL_MS (100)          // hold per fit point
+#define MOTORCAL_DWELL_AVG_MS (50)       // average over the last part of the hold
+#define MOTORCAL_SETTLE_MS (200)         // coast to a stop before ramping
+#define MOTORCAL_PARK_MARGIN (60)        // ADC counts from the end to start a run
+#define MOTORCAL_PARK_DUTY (200)         // open-loop duty used to park
+#define MOTORCAL_PARK_TIMEOUT (2500)     // ms
+#define MOTORCAL_EDGE_MARGIN (25)        // abort if a run gets this close to an end
+
+// Plausibility bounds. Anything outside these means the measurement, not the
+// fader, is wrong - fall back to the compiled defaults rather than trusting it.
+#define MOTORCAL_BD_MIN (10)
+#define MOTORCAL_BD_MAX (180)
+#define MOTORCAL_K_MIN (8)
+#define MOTORCAL_K_MAX (90)
+#define MOTORCAL_VJUMP_MIN (100)
+#define MOTORCAL_VJUMP_MAX (4000)
+
+// The MOVE_* constants above are the DEFAULTS, used by a unit that has never
+// been motor-calibrated. They are not the gains the controller runs: every one
+// of them is really a statement about this unit's friction and torque written
+// in absolute duty, so self-calibration measures those two things directly and
+// derives the live values below (see apply_motor_calibration). A fader whose
+// breakaway or torque differs materially from the reference unit the constants
+// were centred on cannot be served by any single set of numbers - see
+// "Tuning for hardware variance" in ABOUT_MOTOR_CONTROL.md.
+//
+// DEBUG_DRIVE builds additionally let a host overwrite these at runtime via
+// REG_DEBUG_GAINS, so a gain sweep doesn't need a reflash per trial.
+// Plant model and gains in use, indexed [MOTORCAL_FALLING]/[MOTORCAL_RISING]
+// where per-direction. Defaults until a unit is characterised.
+float move_bd[2];                                          // breakaway duty
+float move_inv_k[2];                                       // duty per (ADC/s)
+float move_kv = MOVE_KV;                                   // velocity loop gain
+int16_t move_takeup_duty = MOVE_TAKEUP_DUTY;
+float move_deadband = MOVE_DEADBAND;
+float move_vel_min = MOVE_VEL_MIN;
 #if DEBUG_DRIVE
 // Runtime-tunable copies, so gain sweeps don't need a reflash per trial.
-float move_kp = MOVE_KP;
-float move_kd = MOVE_KD;
-int16_t move_ff_rising = MOVE_FF_RISING;
-int16_t move_ff_falling = MOVE_FF_FALLING;
-float move_deadband = MOVE_DEADBAND;
+float move_vref_slope = MOVE_VREF_SLOPE;
 float move_ramp_rate = MOVE_RAMP_RATE;
-int16_t move_takeup_duty = MOVE_TAKEUP_DUTY;
 float move_takeup_ramp_rate = MOVE_TAKEUP_RAMP_RATE;
 #else
-#define move_kp MOVE_KP
-#define move_kd MOVE_KD
-#define move_ff_rising MOVE_FF_RISING
-#define move_ff_falling MOVE_FF_FALLING
-#define move_deadband MOVE_DEADBAND
+#define move_vref_slope MOVE_VREF_SLOPE
 #define move_ramp_rate MOVE_RAMP_RATE
-#define move_takeup_duty MOVE_TAKEUP_DUTY
 #define move_takeup_ramp_rate MOVE_TAKEUP_RAMP_RATE
 #endif
 
@@ -234,7 +355,6 @@ const float ALPHA = 0.05;
 float input_ewma = 0;
 float stiction_ramp = 0;                // extra drive ramped in while stalled
 float move_max_velocity = MOVE_VEL_UNLIMITED;  // 0 = unlimited
-float move_max_error = 1023.0f;         // matching P-term clamp; large = inactive
 float drive_ceiling = MOVE_MAX_DUTY;    // take-up ceiling, reset at each move start
 float velocity_ewma = 0;                // ADC counts/sec, + toward the motor end
 float last_control_ewma = 0;
@@ -255,19 +375,39 @@ uint16_t touch_recal_count = 0;  // Count of touch recalibrations since boot
 // I2C slave base address (before A0/A1/A2 jumpers are applied)
 const uint8_t I2C_BASE_ADDRESS = 0x20;
 
-// EEPROM calibration storage
+// EEPROM calibration storage. The magic changes whenever the layout does; an
+// older record simply fails validation and the unit falls back to defaults
+// until self-calibration is run again, which it needs anyway.
 #define EEPROM_CALIBRATION_ADDR 0
-#define EEPROM_CALIBRATION_MAGIC 0xCAFE  // Magic number to validate EEPROM data
+#define EEPROM_CALIBRATION_MAGIC 0xCAF1  // Magic number to validate EEPROM data
+
+// Motor characterisation, as measured and as reported at REG_MOTOR_CAL.
+// Held separately from the derived gains so the raw measurement stays
+// inspectable - if a fader misbehaves, these are the numbers worth seeing.
+// Indexed by direction of travel throughout - [MOTORCAL_FALLING] and
+// [MOTORCAL_RISING] - so the measurement, the derivation and the accumulators
+// all address it the same way instead of each carrying its own pair of cases.
+#define MOTORCAL_FALLING (0)
+#define MOTORCAL_RISING (1)
+
+struct MotorCalData {
+  uint8_t valid;      // 0 = never measured, or measured implausibly
+  uint8_t bd[2];      // breakaway duty
+  uint8_t k[2];       // ADC counts/sec per duty above breakaway
+  uint16_t vjump[2];  // ADC counts/sec at the moment motion starts
+};
 
 struct CalibrationData {
   uint16_t magic;         // Magic number for validation
   uint16_t calib_min;     // Minimum ADC value (fader at one end)
   uint16_t calib_max;     // Maximum ADC value (fader at other end)
+  MotorCalData motor;     // Per-unit motor characterisation (valid=0 if absent)
   uint16_t checksum;      // Simple checksum for data integrity
 };
 
 uint16_t input_calib_min = 40;
 uint16_t input_calib_max = 1010;
+MotorCalData motor_cal = {0, {0, 0}, {0, 0}, {0, 0}};
 
 int16_t target_adc = 512;
 uint8_t current_register = REG_VERSION;  // Track which register was last accessed
@@ -372,6 +512,41 @@ uint8_t self_calibration_stage = 0;
 #define SELF_CALIBRATION_BUFFER (0.995)  // Buffer factor to prevent hitting physical limits
 uint16_t self_calibration_adc_stage_0 = 0;
 uint16_t self_calibration_adc_stage_1 = 0;
+
+// Self-calibration runs the endpoint sweep first, then characterises the motor
+// (see the MOTORCAL_* constants). Stages 0-2 are the original endpoint sweep;
+// their numbering is unchanged.
+enum SelfCalStage : uint8_t {
+  SELFCAL_ENDPOINT_LOW = 0,   // drive to the low end, record it
+  SELFCAL_ENDPOINT_HIGH,      // drive to the high end, record it
+  SELFCAL_ENDPOINT_APPLY,     // validate the span, adopt it in RAM
+  SELFCAL_MOTOR_PARK,         // drive to the end this run starts from
+  SELFCAL_MOTOR_SETTLE,       // coast to a genuine stop before measuring
+  SELFCAL_MOTOR_RAMP,         // ramp to breakaway, then hold and capture the jump
+  SELFCAL_MOTOR_DWELL_A,      // hold breakaway + A, measure cruise speed
+  SELFCAL_MOTOR_DWELL_B,      // hold breakaway + B, measure cruise speed
+  SELFCAL_MOTOR_NEXT,         // fold in the run, advance or finish
+  SELFCAL_FINISH,             // derive gains, persist, return to the target
+};
+
+// Motor characterisation working state. Runs alternate direction starting with
+// falling (the endpoint sweep leaves the carriage at the high end), so each run
+// begins where the previous one ended.
+uint8_t motorcal_run = 0;          // 0..2*MOTORCAL_PASSES-1; even falling, odd rising
+bool motorcal_failed = false;
+uint16_t motorcal_duty = 0;        // ramped duty, fixed point (1/64 duty per LSB)
+int16_t motorcal_bd = 0;           // breakaway duty found by this run
+int16_t motorcal_vjump = 0;        // peak speed just after breakaway, ADC/s
+int16_t motorcal_dwell_a = 0;      // cruise speed at breakaway + A, ADC/s
+int32_t motorcal_vel_sum = 0;      // dwell velocity accumulator
+uint16_t motorcal_vel_n = 0;
+// Per-direction accumulators, indexed [0] = falling, [1] = rising. Integer,
+// because flash is the scarce resource on this part and a duty count or an
+// ADC count/sec is all the resolution any of these needs.
+uint16_t motorcal_bd_sum[2] = {0, 0};
+uint16_t motorcal_k_sum[2] = {0, 0};
+uint16_t motorcal_vjump_max[2] = {0, 0};
+uint8_t motorcal_samples[2] = {0, 0};
 
 bool pending_report_on_idle = false;
 
@@ -495,6 +670,19 @@ void setup_tca0() {
   TCA0.SPLIT.CTRLA = TCA_SPLIT_ENABLE_bm | TCA_SPLIT_CLKSEL_DIV4_gc;  // 19.6 kHz
 }
 
+// Big-endian multi-byte replies. Consolidating these into helpers rather than
+// writing the bytes out at each call site is worth real flash on this part -
+// every Wire.write() is a call, and the register handler has a lot of them.
+void i2c_write_u16(uint16_t v) {
+  uint8_t b[2] = {(uint8_t)(v >> 8), (uint8_t)v};
+  Wire.write(b, 2);
+}
+
+void i2c_write_u32(uint32_t v) {
+  uint8_t b[4] = {(uint8_t)(v >> 24), (uint8_t)(v >> 16), (uint8_t)(v >> 8), (uint8_t)v};
+  Wire.write(b, 4);
+}
+
 // I2C request handler - called when master requests data
 // IMPORTANT: This runs in ISR context - only read i2c_ prefixed state!
 void onI2cRequest() {
@@ -502,52 +690,27 @@ void onI2cRequest() {
   if (r == REG_VERSION) {
       Wire.write(I2C_PROTOCOL_VERSION);
   } else if (r == REG_FW_VERSION) {
-      Wire.write((FW_VERSION >> 8) & 0xFF);
-      Wire.write(FW_VERSION & 0xFF);
+      i2c_write_u16(FW_VERSION);
   } else if (r == REG_STATE) {
       // Snapshot once: the main loop can update i2c_outgoing_state between
       // byte writes, which would hand the controller a torn value.
-      uint32_t s = i2c_outgoing_state;
-      Wire.write((s >> 24) & 0xFF);
-      Wire.write((s >> 16) & 0xFF);
-      Wire.write((s >> 8) & 0xFF);
-      Wire.write(s & 0xFF);
+      i2c_write_u32(i2c_outgoing_state);
   } else if (r == REG_UPTIME) {
-      uint32_t uptime = millis();
-      Wire.write((uptime >> 24) & 0xFF);
-      Wire.write((uptime >> 16) & 0xFF);
-      Wire.write((uptime >> 8) & 0xFF);
-      Wire.write(uptime & 0xFF);
+      i2c_write_u32(millis());
   } else if (r == REG_TOUCH_RAW) {
-      uint16_t touch_raw = touch_sensor.sensorData;
-      Wire.write((touch_raw >> 8) & 0xFF);  // High byte
-      Wire.write(touch_raw & 0xFF);         // Low byte
+      i2c_write_u16(touch_sensor.sensorData);
   } else if (r == REG_SERIAL) {
       // Read 10-byte serial number from SIGROW
-      Wire.write(SIGROW.SERNUM0);
-      Wire.write(SIGROW.SERNUM1);
-      Wire.write(SIGROW.SERNUM2);
-      Wire.write(SIGROW.SERNUM3);
-      Wire.write(SIGROW.SERNUM4);
-      Wire.write(SIGROW.SERNUM5);
-      Wire.write(SIGROW.SERNUM6);
-      Wire.write(SIGROW.SERNUM7);
-      Wire.write(SIGROW.SERNUM8);
-      Wire.write(SIGROW.SERNUM9);
+      Wire.write((const uint8_t *)&SIGROW.SERNUM0, 10);
   } else if (r == REG_TOUCH_DELTA) {
       // Touch delta (signed 16-bit): sensorData - reference
-      int16_t delta = ptc_get_node_delta(&touch_sensor);
-      Wire.write((delta >> 8) & 0xFF);  // High byte
-      Wire.write(delta & 0xFF);         // Low byte
+      i2c_write_u16((uint16_t)ptc_get_node_delta(&touch_sensor));
   } else if (r == REG_TOUCH_REF) {
       // Touch reference value (unsigned 16-bit)
-      uint16_t reference = touch_sensor.reference;
-      Wire.write((reference >> 8) & 0xFF);  // High byte
-      Wire.write(reference & 0xFF);         // Low byte
+      i2c_write_u16(touch_sensor.reference);
   } else if (r == REG_TOUCH_RECAL) {
       // Touch recalibration count (unsigned 16-bit)
-      Wire.write((touch_recal_count >> 8) & 0xFF);  // High byte
-      Wire.write(touch_recal_count & 0xFF);         // Low byte
+      i2c_write_u16(touch_recal_count);
 #if DEBUG_DRIVE
   } else if (r == REG_DEBUG_STATUS) {
       int16_t vel = (int16_t)debug_status_velocity;
@@ -558,11 +721,23 @@ void onI2cRequest() {
         debug_status_loop_hz, debug_status_tick_hz,
         (uint16_t)move_max_velocity,
       };
-      for (uint8_t i = 0; i < 9; i++) {
-        Wire.write((vals[i] >> 8) & 0xFF);
-        Wire.write(vals[i] & 0xFF);
-      }
+      for (uint8_t i = 0; i < 9; i++) i2c_write_u16(vals[i]);
 #endif
+  } else if (r == REG_MOTOR_CAL) {
+      const uint8_t vals[12] = {
+        motor_cal.valid,
+        motor_cal.bd[MOTORCAL_RISING], motor_cal.bd[MOTORCAL_FALLING],
+        motor_cal.k[MOTORCAL_RISING], motor_cal.k[MOTORCAL_FALLING],
+        (uint8_t)(motor_cal.vjump[MOTORCAL_RISING] >> 8),
+        (uint8_t)motor_cal.vjump[MOTORCAL_RISING],
+        (uint8_t)(motor_cal.vjump[MOTORCAL_FALLING] >> 8),
+        (uint8_t)motor_cal.vjump[MOTORCAL_FALLING],
+        // What the control law actually runs with, derived or default, so a
+        // host can see the outcome without knowing how it is derived.
+        (uint8_t)(((uint16_t)move_vel_min) >> 8), (uint8_t)move_vel_min,
+        (uint8_t)move_deadband,
+      };
+      Wire.write(vals, 12);
   } else if (r == REG_ACTIVE_LAYER) {
       Wire.write(active_layer);
   } else if (r == REG_LAYER_TARGET) {
@@ -668,14 +843,95 @@ void onI2cReceive(int howMany) {
 
 }
 
+// Re-derive the live control gains from this unit's measured motor
+// characteristics, or restore the compiled-in defaults when no valid
+// measurement exists. Safe to call at any time; it only touches gains.
+//
+// Everything here is a restatement of the MOVE_* defaults in terms of the
+// plant rather than in absolute duty:
+//   FF       = breakaway + (a fixed SPEED of headroom), not a fixed duty
+//   KP, KD   = scaled by k_ref/k, holding the real loop gains KP*k and KD*k
+//              constant, and with them the KP/KD ratio the coast-in relies on
+//   deadband = at least the distance covered by this unit's Stribeck jump
+//   take-up  = above FF, which is an invariant of the take-up ceiling
+// At the reference unit's measurements this reproduces the shipped values.
+void apply_motor_calibration() {
+  // The compiled-in defaults are themselves a plant model - the reference
+  // unit's - so there is one derivation, not one per case. That is not just
+  // tidiness: it guarantees an uncharacterised fader runs exactly the gains
+  // the constants were tuned to, because they are computed the same way.
+  uint8_t bd[2], k[2];
+  uint16_t vjump;
+  if (motor_cal.valid) {
+    bd[MOTORCAL_FALLING] = motor_cal.bd[MOTORCAL_FALLING];
+    bd[MOTORCAL_RISING] = motor_cal.bd[MOTORCAL_RISING];
+    k[MOTORCAL_FALLING] = motor_cal.k[MOTORCAL_FALLING];
+    k[MOTORCAL_RISING] = motor_cal.k[MOTORCAL_RISING];
+    vjump = (motor_cal.vjump[0] > motor_cal.vjump[1]) ? motor_cal.vjump[0]
+                                                      : motor_cal.vjump[1];
+  } else {
+    bd[MOTORCAL_FALLING] = MOVE_BD_FALLING;
+    bd[MOTORCAL_RISING] = MOVE_BD_RISING;
+    k[MOTORCAL_FALLING] = MOVE_K_DEFAULT;
+    k[MOTORCAL_RISING] = MOVE_K_DEFAULT;
+    vjump = MOVE_VJUMP_DEFAULT;
+  }
+
+  // The Stribeck jump is the slowest the mechanism moves at all, so it floors
+  // both the velocity reference and the on-target window: the fader cannot
+  // correct by less than the distance it covers before it can be stopped.
+  uint16_t vel_min = vjump + vjump / 4;  // 1.25x, for margin above the floor
+  if (vel_min < MOTORCAL_VEL_MIN_LO) vel_min = MOTORCAL_VEL_MIN_LO;
+  if (vel_min > MOTORCAL_VEL_MIN_HI) vel_min = MOTORCAL_VEL_MIN_HI;
+  move_vel_min = vel_min;
+
+  uint16_t deadband = (uint16_t)(((uint32_t)vel_min * MOTORCAL_STOP_TIME_MS + 500) / 1000);
+  if (deadband < MOTORCAL_DEADBAND_LO) deadband = MOTORCAL_DEADBAND_LO;
+  if (deadband > MOTORCAL_DEADBAND_HI) deadband = MOTORCAL_DEADBAND_HI;
+  move_deadband = deadband;
+
+  // Take-up ceiling: limits drive at the start of a move so the belt is not
+  // engaged at full duty. It has to stay above the feedforward at the floor
+  // speed, or it starves the term that gets the carriage moving. Integer
+  // arithmetic deliberately - this runs once, but flash is permanent.
+  int16_t takeup = MOVE_TAKEUP_DUTY;
+  for (uint8_t i = 0; i < 2; i++) {
+    int16_t ff = bd[i] + (int16_t)(vel_min / (k[i] ? k[i] : 1)) + MOTORCAL_TAKEUP_MARGIN;
+    if (ff > takeup) takeup = ff;
+  }
+  if (takeup > MOVE_MAX_DUTY) takeup = MOVE_MAX_DUTY;
+  move_takeup_duty = takeup;
+
+  // The only float work: the control law needs 1/k per direction for the
+  // feedforward, and the velocity loop gain scaled so its open-loop gain k*KV
+  // - the thing that actually sets damping - matches the reference unit's.
+  uint16_t k_avg = ((uint16_t)k[0] + k[1] + 1) / 2;
+  if (k_avg < MOTORCAL_K_MIN) k_avg = MOTORCAL_K_MIN;
+  if (k_avg > MOTORCAL_K_MAX) k_avg = MOTORCAL_K_MAX;
+  move_kv = MOTORCAL_KV_LOOP_GAIN / (float)k_avg;
+  for (uint8_t i = 0; i < 2; i++) {
+    move_bd[i] = bd[i];
+    move_inv_k[i] = 1.0f / (float)(k[i] ? k[i] : 1);
+  }
+}
+
+// Checksum over everything in the record except the checksum itself.
+uint16_t calibration_checksum(const CalibrationData &cal) {
+  uint16_t sum = cal.magic + cal.calib_min + cal.calib_max + cal.motor.valid;
+  for (uint8_t i = 0; i < 2; i++) {
+    sum += cal.motor.bd[i] + cal.motor.k[i] + cal.motor.vjump[i];
+  }
+  return sum;
+}
+
 // Save calibration data to EEPROM
 void saveCalibration() {
   CalibrationData cal;
   cal.magic = EEPROM_CALIBRATION_MAGIC;
   cal.calib_min = input_calib_min;
   cal.calib_max = input_calib_max;
-  // Simple checksum: sum of all data
-  cal.checksum = cal.magic + cal.calib_min + cal.calib_max;
+  cal.motor = motor_cal;
+  cal.checksum = calibration_checksum(cal);
 
   EEPROM.put(EEPROM_CALIBRATION_ADDR, cal);
 }
@@ -692,8 +948,7 @@ bool loadCalibration() {
   }
 
   // Validate checksum
-  uint16_t expected_checksum = cal.magic + cal.calib_min + cal.calib_max;
-  if (cal.checksum != expected_checksum) {
+  if (cal.checksum != calibration_checksum(cal)) {
     return false;
   }
 
@@ -710,19 +965,28 @@ bool loadCalibration() {
   // Load calibration values
   input_calib_min = cal.calib_min;
   input_calib_max = cal.calib_max;
+  motor_cal = cal.motor;
 
   return true;
 }
 
 void setup_i2c() {
-  pinMode(PIN_ADDR_0, INPUT_PULLUP);
-  pinMode(PIN_ADDR_1, INPUT_PULLUP);
-  pinMode(PIN_ADDR_2, INPUT_PULLUP);
+  // Straight to the port. The three address jumpers are PC0-PC2, read once at
+  // boot, and going through pinMode()/digitalRead() for them links both
+  // functions (~120 bytes) for no benefit.
+  PORTC.PIN0CTRL |= PORT_PULLUPEN_bm;
+  PORTC.PIN1CTRL |= PORT_PULLUPEN_bm;
+  PORTC.PIN2CTRL |= PORT_PULLUPEN_bm;
+  _delay_us(10);  // let the pullups settle before sampling
 
+  // A fitted jumper pulls its pin low, so the bits are inverted. Note the
+  // address pins run the opposite way round from the port bits: PIN_ADDR_0 is
+  // PC2 and PIN_ADDR_2 is PC0, so the three bits are reversed, not copied.
+  uint8_t fitted = (~VPORTC.IN) & 0x07;  // bit n set = jumper on PCn
   uint8_t address = I2C_BASE_ADDRESS +
-    (!digitalRead(PIN_ADDR_2) << 2) +
-    (!digitalRead(PIN_ADDR_1) << 1) +
-    (!digitalRead(PIN_ADDR_0) << 0);
+    ((fitted & (1 << 0)) << 2) +  // PC0 -> A2
+    ((fitted & (1 << 1))) +       // PC1 -> A1
+    ((fitted & (1 << 2)) >> 2);   // PC2 -> A0
 
   // Initialize I2C as slave
   Wire.begin(address);
@@ -747,6 +1011,15 @@ void increment_double_tap_nonce() {
 
 void reset_tap_detection() {
   tap_state = TAP_NONE;
+}
+
+// How far the carriage has moved since the tap started. Raw ADC deliberately,
+// not input_ewma: the filter's lag is comparable to the tap timings being
+// judged here, so a filtered value would report movement that already ended.
+uint16_t tap_position_delta() {
+  uint16_t current_adc = ADC1.RES;
+  return (current_adc > tap_position_start) ? (current_adc - tap_position_start)
+                                            : (tap_position_start - current_adc);
 }
 
 // Calculate max PWM from 3-bit strength value (0-7)
@@ -806,6 +1079,17 @@ void request_layer_change(uint8_t new_layer) {
   pending_layer_change = new_layer;  // Defer until appropriate to apply
 }
 
+// Enter (or restart) a remote move toward the current target_adc. Every caller
+// needs the same three timestamps reset together - a half-reset move either
+// times out early or never does.
+void begin_remote_move() {
+  uint32_t now = millis();
+  remote_movement_start = now;
+  remote_movement_start_position = input_ewma;
+  remote_movement_steady_start = now;
+  set_mode(MODE_REMOTE_MOVEMENT_IN_PROGRESS);
+}
+
 // Apply layer change and start movement to new layer's restore position
 void apply_layer_change(uint8_t new_layer) {
   // Start movement to new layer's restore position
@@ -814,10 +1098,7 @@ void apply_layer_change(uint8_t new_layer) {
     input_calib_min, input_calib_max
   );
   apply_move_speed(layer_speeds[new_layer]);
-  remote_movement_start = millis();
-  remote_movement_start_position = input_ewma;
-  remote_movement_steady_start = millis();
-  set_mode(MODE_REMOTE_MOVEMENT_IN_PROGRESS);
+  begin_remote_move();
 
   // Load new layer's haptic config
   haptic_config = layer_haptic_configs[new_layer];
@@ -831,26 +1112,15 @@ void write_layer_target(uint8_t layer, uint8_t target) {
   if (layer > 7) return;
 
   if (layer == active_layer) {
+    // Starting a move and retargeting one already under way are the same
+    // thing. Anything else - the user has control, an error is latched, a
+    // calibration is running - leaves the fader alone.
     Mode mode = get_mode();
-    if (mode == MODE_INPUT_IDLE) {
-      // Start remote movement
+    if (mode == MODE_INPUT_IDLE || mode == MODE_REMOTE_MOVEMENT_IN_PROGRESS) {
       layer_restore_positions[layer] = target;
       target_adc = BOUNDED_LERP_UINT16(target, 0, 255, input_calib_min, input_calib_max);
       apply_move_speed(layer_speeds[layer]);
-      set_mode(MODE_REMOTE_MOVEMENT_IN_PROGRESS);
-      remote_movement_start = millis();
-      remote_movement_start_position = input_ewma;
-      remote_movement_steady_start = millis();
-    } else if (mode == MODE_INPUT_ACTIVE) {
-      // Ignore - user has control
-    } else if (mode == MODE_REMOTE_MOVEMENT_IN_PROGRESS) {
-      // Update target of in-progress movement
-      layer_restore_positions[layer] = target;
-      target_adc = BOUNDED_LERP_UINT16(target, 0, 255, input_calib_min, input_calib_max);
-      apply_move_speed(layer_speeds[layer]);
-      remote_movement_start = millis();
-      remote_movement_start_position = input_ewma;
-      remote_movement_steady_start = millis();
+      begin_remote_move();
     }
   } else {
     // Non-active layer - just update restore position
@@ -904,22 +1174,39 @@ void adc_drain() {
 void apply_move_speed(uint8_t speed) {
   if (speed >= LAYER_SPEED_FULL) {
     move_max_velocity = MOVE_VEL_UNLIMITED;
-    move_max_error = 1023.0f;
     return;
   }
+  // Integer throughout: the result is an ADC-counts/sec limit that the plant
+  // only honours to within ~15% anyway, so sub-count precision here would buy
+  // nothing and float on this part is not free.
   uint16_t span = input_calib_max - input_calib_min;
-  float slowest = (float)span * 1000.0f / MOVE_SPEED_SLOWEST_MS;
-  float fastest = (float)span * 1000.0f / MOVE_SPEED_FASTEST_MS;
-  float adc_per_sec =
-      slowest + (fastest - slowest) * ((float)speed / (float)(LAYER_SPEED_FULL - 1));
+  uint16_t slowest = ((uint32_t)span * 1000) / MOVE_SPEED_SLOWEST_MS;
+  // The fast endpoint divides 1000 exactly, so it stays in 16-bit arithmetic
+  // (span is at most 1023, so span * 4 cannot overflow). The static_asserts
+  // keep that true if the endpoint is ever re-measured and changed.
+  static_assert(1000 % MOVE_SPEED_FASTEST_MS == 0,
+                "MOVE_SPEED_FASTEST_MS must divide 1000 exactly, or use 32-bit math here");
+  static_assert(1023UL * (1000 / MOVE_SPEED_FASTEST_MS) <= 65535UL, "span scaling overflows");
+  uint16_t fastest = span * (1000 / MOVE_SPEED_FASTEST_MS);
+  uint16_t adc_per_sec =
+      slowest + (uint16_t)(((uint32_t)(fastest - slowest) * speed) / (LAYER_SPEED_FULL - 1));
   // Clamp to what the mechanism can actually sustain smoothly
-  if (adc_per_sec < MOVE_VEL_MIN) adc_per_sec = MOVE_VEL_MIN;
+  if (adc_per_sec < move_vel_min) adc_per_sec = move_vel_min;
   move_max_velocity = adc_per_sec;
-  // Matching error clamp, so the proportional term cannot saturate past the
-  // point where the governor has any authority.
-  float clamp = adc_per_sec / MOVE_VELOCITY_PER_ERROR;
-  if (clamp < MOVE_DEADBAND * 2) clamp = MOVE_DEADBAND * 2;
-  move_max_error = clamp;
+}
+
+// Direction of travel for the current characterisation run: runs alternate,
+// starting with falling, so each begins where the previous one ended.
+int8_t motorcal_dir() {
+  return (motorcal_run & 1) ? 1 : -1;
+}
+
+// A run drives open-loop, so it has to police its own travel. Bail out before
+// the carriage reaches the mechanical end rather than measuring a fader that
+// is being held by an endstop.
+bool motorcal_out_of_band(int8_t dir) {
+  if (dir > 0) return input_ewma > input_calib_max - MOTORCAL_EDGE_MARGIN;
+  return input_ewma < input_calib_min + MOTORCAL_EDGE_MARGIN;
 }
 
 void motor_update() {
@@ -1021,44 +1308,61 @@ void motor_update() {
         }
         float error = target_adc - input_ewma;
         if (error > move_deadband || error < -move_deadband) {
-          // PD on position plus a friction feedforward, which covers the
-          // breakaway duty so the controller only has to supply the part of
-          // the drive that sets speed rather than fighting stiction. The D term
-          // is what prevents overshoot: it cancels the feedforward while the
-          // carriage is still moving fast, cutting drive roughly one stopping
-          // distance short of the target so it coasts in.
+          // Cascade control. The position loop asks for a velocity, the
+          // velocity loop delivers it:
+          //
+          //   v_ref = clamp(slope * error, floor .. speed limit)
+          //   u     = breakaway + v_ref/k          (feedforward)
+          //         + KV * (v_ref - v)             (feedback)
+          //
+          // The feedforward is the plant model inverted, so at steady state the
+          // feedback term is zero and the fader simply travels at v_ref. That
+          // is what makes the speed limit a limit rather than a fight: the old
+          // law carried a fixed feedforward that commanded ~1100 ADC/s no
+          // matter what was asked for, and needed a one-sided governor to
+          // subtract drive back off once the fader was already too fast. A
+          // one-sided correction with the operating point sitting exactly on
+          // its discontinuity is a limit-cycle generator, and it behaved like
+          // one: overshoot the limit, brake, fall under, accelerate again.
+          //
+          // Clamping the reference instead keeps one well-damped loop in charge
+          // at every speed, and the same clamp replaces the separate P-term
+          // error clamp the governor needed to stop KP saturating.
+          float v_ref = move_vref_slope * error;
+          float mag = v_ref < 0 ? -v_ref : v_ref;
+          if (move_max_velocity > MOVE_VEL_UNLIMITED && mag > move_max_velocity) {
+            mag = move_max_velocity;
+          }
+          // Never ask for less than the mechanism can actually sustain: below
+          // the Stribeck floor it stick-slips rather than moving, and holding
+          // the reference here is also what keeps the feedforward clear of
+          // breakaway when the error is small.
+          if (mag < move_vel_min) mag = move_vel_min;
 
-          // Clamp the error driving the P term when a speed limit is active.
-          // Inactive near the target and when unlimited, so the tuned approach
-          // and settle behaviour is unchanged.
-          float e_ctrl = error;
-          if (e_ctrl > move_max_error) e_ctrl = move_max_error;
-          if (e_ctrl < -move_max_error) e_ctrl = -move_max_error;
+          uint8_t d = (error > 0) ? MOTORCAL_RISING : MOTORCAL_FALLING;
+          float ff = move_bd[d] + mag * move_inv_k[d];
+          if (error < 0) ff = -ff;
+          v_ref = (error > 0) ? mag : -mag;
+          float u = ff + move_kv * (v_ref - velocity_ewma);
 
-          float u = move_kp * e_ctrl - move_kd * velocity_ewma;
-          u += (error > 0) ? move_ff_rising : -move_ff_falling;
-
-          // Ramp in extra drive only while stalled, and shed it as soon as the
-          // carriage moves, so the ramp never contributes to overshoot.
+          // Ramp in extra drive only while stalled. The feedforward is derived
+          // to sit above breakaway, so this should now be rare - it covers
+          // measurement error, a cold or stiff unit, and the uncharacterised
+          // case.
           float speed = velocity_ewma < 0 ? -velocity_ewma : velocity_ewma;
           if (speed < MOVE_STALL_VELOCITY) {
             stiction_ramp += move_ramp_rate * (control_dt_us * 1e-6f);
             if (stiction_ramp > MOVE_RAMP_MAX) stiction_ramp = MOVE_RAMP_MAX;
-          } else {
-            stiction_ramp = 0;
+          } else if (stiction_ramp > 0) {
+            // Shed it quickly once the carriage breaks free, but not in one
+            // step: dropping up to MOVE_RAMP_MAX of drive instantly is itself a
+            // relay, and around the stall threshold it chatters. A few tens of
+            // ms is far shorter than the coast time, so it still cannot
+            // contribute to overshoot.
+            stiction_ramp -= MOVE_RAMP_DECAY_RATE * (control_dt_us * 1e-6f);
+            if (stiction_ramp < 0) stiction_ramp = 0;
           }
           u += (error > 0) ? stiction_ramp : -stiction_ramp;
-
-          // Optional velocity limit: bleed off drive only while over the
-          // requested speed, so approach and settle near the target (already
-          // slower than any useful limit) are unaffected.
-          if (move_max_velocity > MOVE_VEL_UNLIMITED) {
-            float speed_now = velocity_ewma < 0 ? -velocity_ewma : velocity_ewma;
-            if (speed_now > move_max_velocity) {
-              float excess = MOVE_VEL_LIMIT_GAIN * (speed_now - move_max_velocity);
-              u += (velocity_ewma > 0) ? -excess : excess;
-            }
-          }
 
           // Drive ceiling opens up over time from the take-up value, easing
           // the motor through belt backlash instead of stepping to full duty.
@@ -1181,9 +1485,23 @@ void motor_update() {
     case MODE_ERROR:
       motor_set(0, false, MOTOR_IDLE_COAST);
       break;
-    case MODE_SELF_CALIBRATION:
+    case MODE_SELF_CALIBRATION: {
+      // Direction of travel and travel policing are the same for every
+      // measurement stage, so they live here rather than in each case. The
+      // runs drive open loop, so something has to stop them at the ends.
+      int8_t dir = motorcal_dir();
+      // Speed along the direction of travel, as an integer once, so the
+      // measurement stages below never touch the float paths again. One ADC
+      // count/sec is far finer than anything derived from these needs.
+      int16_t speed = (int16_t)((dir > 0) ? velocity_ewma : -velocity_ewma);
+      if (self_calibration_stage >= SELFCAL_MOTOR_RAMP &&
+          self_calibration_stage <= SELFCAL_MOTOR_DWELL_B &&
+          motorcal_out_of_band(dir)) {
+        motorcal_failed = true;
+        self_calibration_stage = SELFCAL_MOTOR_NEXT;
+      }
       switch (self_calibration_stage) {
-        case 0:
+        case SELFCAL_ENDPOINT_LOW:
           if (now > self_calibration_start + SELF_CALIBRATION_TIMEOUT) {
             self_calibration_adc_stage_0 = adc_val;
             self_calibration_stage++;
@@ -1193,7 +1511,7 @@ void motor_update() {
             motor_set(-254, true, MOTOR_IDLE_COAST);
           }
           break;
-        case 1:
+        case SELFCAL_ENDPOINT_HIGH:
           if (now > self_calibration_start + SELF_CALIBRATION_TIMEOUT) {
             self_calibration_adc_stage_1 = adc_val;
             self_calibration_stage++;
@@ -1203,7 +1521,7 @@ void motor_update() {
             motor_set(254, true, MOTOR_IDLE_COAST);
           }
           break;
-        case 2:
+        case SELFCAL_ENDPOINT_APPLY:
           motor_set(0, false, MOTOR_IDLE_COAST);
           if (abs((int16_t)self_calibration_adc_stage_0 - self_calibration_adc_stage_1) < 900) {
             set_mode(Mode::MODE_ERROR);
@@ -1213,19 +1531,185 @@ void motor_update() {
             input_calib_min = (SELF_CALIBRATION_BUFFER * self_calibration_adc_stage_0 + (1.0 - SELF_CALIBRATION_BUFFER) * self_calibration_adc_stage_1) / 2;
             input_calib_max = (SELF_CALIBRATION_BUFFER * self_calibration_adc_stage_1 + (1.0 - SELF_CALIBRATION_BUFFER) * self_calibration_adc_stage_0) / 2;
 
-            // Save calibration to EEPROM
-            saveCalibration();
-
-            // Since we moved the position, do a remote movement to the previous target
-            remote_movement_start = millis();
-            remote_movement_start_position = input_ewma;
-            remote_movement_steady_start = millis();
-            // TODO: re-calculate target_adc using the new calibration bounds. Can't do that now since we lerp target to an ADC value upon receipt, without saving the 0-255 value
-            set_mode(Mode::MODE_REMOTE_MOVEMENT_IN_PROGRESS);
+            // Endpoints are known, so the motor characterisation that follows
+            // has a calibrated span to keep itself inside. Persist once, at the
+            // end, so endpoints and motor data are written together.
+            motorcal_run = 0;
+            motorcal_failed = false;
+            for (uint8_t i = 0; i < 2; i++) {
+              motorcal_bd_sum[i] = 0;
+              motorcal_k_sum[i] = 0;
+              motorcal_vjump_max[i] = 0;
+              motorcal_samples[i] = 0;
+            }
+            self_calibration_stage = SELFCAL_MOTOR_PARK;
+            self_calibration_start = now;
           }
+          break;
+        case SELFCAL_MOTOR_PARK: {
+          // A run needs room to ramp to breakaway and then dwell twice without
+          // reaching the far end, so it starts from the end it travels away
+          // from. Runs alternate direction, so only the first park is long.
+          bool parked = (dir > 0)
+              ? (input_ewma <= input_calib_min + MOTORCAL_PARK_MARGIN)
+              : (input_ewma >= input_calib_max - MOTORCAL_PARK_MARGIN);
+          if (parked || now > self_calibration_start + MOTORCAL_PARK_TIMEOUT) {
+            motor_set(0, true, MOTOR_IDLE_BRAKE);
+            self_calibration_stage = SELFCAL_MOTOR_SETTLE;
+            self_calibration_start = now;
+          } else {
+            motor_set(dir > 0 ? -MOTORCAL_PARK_DUTY : MOTORCAL_PARK_DUTY,
+                      true, MOTOR_IDLE_COAST);
+          }
+          break;
+        }
+        case SELFCAL_MOTOR_SETTLE:
+          // Breakaway is only meaningful from a standstill: measuring it while
+          // the carriage still coasts would find the (much lower) duty needed
+          // to sustain motion rather than the duty needed to start it.
+          motor_set(0, true, MOTOR_IDLE_BRAKE);
+          if (now > self_calibration_start + MOTORCAL_SETTLE_MS) {
+            motorcal_duty = 0;
+            motorcal_bd = 0;
+            motorcal_vjump = 0;
+            self_calibration_stage = SELFCAL_MOTOR_RAMP;
+            self_calibration_start = now;
+          }
+          break;
+        case SELFCAL_MOTOR_RAMP: {
+          int16_t duty;
+          if (motorcal_bd == 0) {
+            // Still hunting for breakaway. Fixed point, 1/256 duty per LSB:
+            // the ramp is the only thing here needing sub-duty resolution, and
+            // a float multiply per tick for it is not worth the flash. The
+            // fraction has to be fine enough that a tick's increment does not
+            // truncate to nothing - 84/4096 per us is 80.1 duty/sec at the
+            // 500 us tick, where a coarser LSB would quietly give ~62.
+            motorcal_duty += (uint16_t)((control_dt_us * 84UL) >> 12);
+            duty = motorcal_duty >> 8;
+            if (duty > MOTORCAL_RAMP_MAX) {
+              // Nothing moved short of a duty no sane fader needs: jammed, or
+              // the motor isn't connected.
+              motorcal_failed = true;
+              self_calibration_stage = SELFCAL_MOTOR_NEXT;
+              break;
+            }
+            // duty > 0 keeps a still-coasting carriage from "breaking away" at
+            // zero drive, which would also defeat the sentinel below.
+            if (duty > 0 && speed > MOTORCAL_MOTION_VEL) {
+              motorcal_bd = duty;
+              motorcal_vjump = speed;
+              self_calibration_start = now;  // start the jump hold
+            }
+          } else {
+            // Breakaway found (motorcal_bd is the sentinel; it is never 0 for
+            // a real detection). Hold there and take the peak speed. Motion does
+            // not ease in from zero - it jumps (Stribeck) - and that jump is
+            // the floor on the smallest correction the controller can make.
+            duty = motorcal_bd;
+            if (speed > motorcal_vjump) motorcal_vjump = speed;
+            if (now > self_calibration_start + MOTORCAL_JUMP_MS) {
+              motorcal_vel_sum = 0;
+              motorcal_vel_n = 0;
+              self_calibration_stage = SELFCAL_MOTOR_DWELL_A;
+              self_calibration_start = now;
+            }
+          }
+          motor_set((dir > 0) ? duty : -duty, true, MOTOR_IDLE_BRAKE);
+          break;
+        }
+        case SELFCAL_MOTOR_DWELL_A:
+        case SELFCAL_MOTOR_DWELL_B: {
+          // Two fixed duties above breakaway give a two-point fit for k, the
+          // slope of the speed/duty line. One point would only give a speed,
+          // which says nothing about how the plant responds to a change.
+          bool second = (self_calibration_stage == SELFCAL_MOTOR_DWELL_B);
+          int16_t duty = motorcal_bd + (second ? MOTORCAL_DWELL_B : MOTORCAL_DWELL_A);
+          if (duty > MOVE_MAX_DUTY) duty = MOVE_MAX_DUTY;
+          motor_set((dir > 0) ? duty : -duty, true, MOTOR_IDLE_BRAKE);
+
+          // Average the tail of the hold only, once the speed has settled.
+          if (now > self_calibration_start + (MOTORCAL_DWELL_MS - MOTORCAL_DWELL_AVG_MS)) {
+            motorcal_vel_sum += speed;
+            motorcal_vel_n++;
+          }
+          if (now > self_calibration_start + MOTORCAL_DWELL_MS) {
+            int16_t v = (motorcal_vel_n > 0)
+                            ? (int16_t)(motorcal_vel_sum / motorcal_vel_n)
+                            : 0;
+            motorcal_vel_sum = 0;
+            motorcal_vel_n = 0;
+            if (!second) {
+              motorcal_dwell_a = v;
+              self_calibration_stage = SELFCAL_MOTOR_DWELL_B;
+              self_calibration_start = now;
+            } else {
+              int16_t k = (v - motorcal_dwell_a) / (MOTORCAL_DWELL_B - MOTORCAL_DWELL_A);
+              int16_t bd = motorcal_bd;
+              int16_t vjump = motorcal_vjump;
+              uint8_t idx = (dir > 0) ? MOTORCAL_RISING : MOTORCAL_FALLING;
+              if (bd >= MOTORCAL_BD_MIN && bd <= MOTORCAL_BD_MAX &&
+                  k >= MOTORCAL_K_MIN && k <= MOTORCAL_K_MAX &&
+                  vjump >= MOTORCAL_VJUMP_MIN && vjump <= MOTORCAL_VJUMP_MAX) {
+                motorcal_bd_sum[idx] += bd;
+                motorcal_k_sum[idx] += k;
+                if ((uint16_t)vjump > motorcal_vjump_max[idx]) {
+                  motorcal_vjump_max[idx] = vjump;
+                }
+                motorcal_samples[idx]++;
+              } else {
+                motorcal_failed = true;
+              }
+              self_calibration_stage = SELFCAL_MOTOR_NEXT;
+              self_calibration_start = now;
+            }
+          }
+          break;
+        }
+        case SELFCAL_MOTOR_NEXT:
+          motor_set(0, true, MOTOR_IDLE_BRAKE);
+          motorcal_run++;
+          self_calibration_stage =
+              (!motorcal_failed && motorcal_run < 2 * MOTORCAL_PASSES)
+                  ? SELFCAL_MOTOR_PARK
+                  : SELFCAL_FINISH;
+          self_calibration_start = now;
+          break;
+        case SELFCAL_FINISH:
+          motor_set(0, false, MOTOR_IDLE_COAST);
+          // Every run must have produced a plausible sample. A partial set
+          // means something was wrong with the fader or the measurement, and
+          // half-measured gains are worse than the tuned defaults.
+          if (!motorcal_failed && motorcal_samples[MOTORCAL_FALLING] == MOTORCAL_PASSES &&
+              motorcal_samples[MOTORCAL_RISING] == MOTORCAL_PASSES) {
+            motor_cal.valid = 1;
+            for (uint8_t i = 0; i < 2; i++) {
+              motor_cal.bd[i] = (motorcal_bd_sum[i] + MOTORCAL_PASSES / 2) / MOTORCAL_PASSES;
+              motor_cal.k[i] = (motorcal_k_sum[i] + MOTORCAL_PASSES / 2) / MOTORCAL_PASSES;
+              motor_cal.vjump[i] = motorcal_vjump_max[i];
+            }
+          } else {
+            // Endpoints are still good and worth keeping; only the motor
+            // characterisation is discarded, and the tuned defaults stand in.
+            motor_cal.valid = 0;
+            for (uint8_t i = 0; i < 2; i++) {
+              motor_cal.bd[i] = 0;
+              motor_cal.k[i] = 0;
+              motor_cal.vjump[i] = 0;
+            }
+          }
+          apply_motor_calibration();
+
+          // Save calibration to EEPROM
+          saveCalibration();
+
+          // Since we moved the position, do a remote movement to the previous target
+          // TODO: re-calculate target_adc using the new calibration bounds. Can't do that now since we lerp target to an ADC value upon receipt, without saving the 0-255 value
+          begin_remote_move();
           break;
       }
       break;
+    }
     }
 
   // TODO: lerp bounds...
@@ -1272,19 +1756,24 @@ void setup() {
   Serial.println("Hello world!");
 #endif
 
-  // Load calibration from EEPROM if available
-  if (loadCalibration()) {
+  // Load calibration from EEPROM if available; defaults stand if there is none.
+  bool have_calibration = loadCalibration();
+  // Unconditional, and after the load either way: the derived gains have no
+  // compile-time initialiser, so a unit with no stored calibration still has to
+  // run the derivation to pick up the default plant model.
+  apply_motor_calibration();
 #if SERIAL_ENABLED
+  if (have_calibration) {
     Serial.print("Loaded calibration from EEPROM: min=");
     Serial.print(input_calib_min);
     Serial.print(", max=");
     Serial.println(input_calib_max);
-#endif
   } else {
-#if SERIAL_ENABLED
     Serial.println("No valid calibration found, using defaults");
-#endif
   }
+#else
+  (void)have_calibration;
+#endif
 
   // Initialize all layers with default configuration (Protocol v5+)
   for (uint8_t i = 0; i < 8; i++) {
@@ -1301,17 +1790,18 @@ void setup() {
 
   setup_i2c();
 
-  pinMode(PIN_LED, OUTPUT);
-  pinMode(PIN_FADER, INPUT);
-  pinMode(PIN_MOTOR_nSLEEP, OUTPUT);
-  pinMode(PIN_MOTOR_A, OUTPUT);
-  pinMode(PIN_MOTOR_B, OUTPUT);
+  // Direct port setup, for the same reason as the address pins above.
+  // PB2 LED, PB3 nSLEEP out; PA4/PA5 motor out; PA6 fader in.
+  VPORTB.DIR |= LED_bm | MOTOR_nSLEEP_bm;
+  VPORTA.DIR |= MOTOR_A_bm | MOTOR_B_bm;
+  VPORTA.DIR &= ~(1 << 6);
 
   // Set up TCA0 for high-frequency PWM
   setup_tca0();
   
-  digitalWrite(PIN_MOTOR_nSLEEP, HIGH);
-  digitalWrite(PIN_LED, HIGH);
+  // Direct to the port, as in loop(): these two calls are the only reason
+  // digitalWrite() would be linked in at all, and it costs 160 bytes.
+  VPORTB.OUT |= MOTOR_nSLEEP_bm | LED_bm;
 
   // Init ADC1 for free-running motor fader input.
   // Using ADC1 with raw setup rather than megaTinyCore's analogRead helpers since
@@ -1437,10 +1927,14 @@ void process_i2c_requests() {
 #if DEBUG_DRIVE
   if (has_debug_gain) {
     switch (debug_gain_index) {
-      case DEBUG_GAIN_KP:         move_kp = debug_gain_value / 1000.0f; break;
-      case DEBUG_GAIN_KD:         move_kd = debug_gain_value / 1000.0f; break;
-      case DEBUG_GAIN_FF_RISING:  move_ff_rising = debug_gain_value; break;
-      case DEBUG_GAIN_FF_FALLING: move_ff_falling = debug_gain_value; break;
+      case DEBUG_GAIN_VREF_SLOPE: move_vref_slope = debug_gain_value / 1000.0f; break;
+      case DEBUG_GAIN_KV:         move_kv = debug_gain_value / 1000.0f; break;
+      case DEBUG_GAIN_BD_RISING:  move_bd[MOTORCAL_RISING] = debug_gain_value; break;
+      case DEBUG_GAIN_BD_FALLING: move_bd[MOTORCAL_FALLING] = debug_gain_value; break;
+      case DEBUG_GAIN_K:
+        move_inv_k[0] = move_inv_k[1] = 1.0f / (float)(debug_gain_value ? debug_gain_value : 1);
+        break;
+      case DEBUG_GAIN_VEL_MIN:    move_vel_min = debug_gain_value; break;
       case DEBUG_GAIN_DEADBAND:   move_deadband = debug_gain_value / 1000.0f; break;
       case DEBUG_GAIN_RAMP_RATE:  move_ramp_rate = debug_gain_value; break;
       case DEBUG_GAIN_TAKEUP:     move_takeup_duty = debug_gain_value; break;
@@ -1535,9 +2029,13 @@ void loop() {
 
   ptc_process(millis());
 
-  // digitalWrite(PIN_LED, (state & STATE_TOUCH_bm) >> STATE_TOUCH_bp);
-  digitalWrite(PIN_LED, (motor_drive_value != 0) || (millis() % 512 < 128));
-  // digitalWrite(PIN_LED, millis()%512 < 128 || touch);
+  // Straight to the port: digitalWrite() is ~180 bytes of pin lookup for a
+  // heartbeat LED on a part with no flash to spare.
+  if ((motor_drive_value != 0) || (millis() % 512 < 128)) {
+    VPORTB.OUT |= LED_bm;
+  } else {
+    VPORTB.OUT &= ~LED_bm;
+  }
 
 }
 
@@ -1558,14 +2056,9 @@ void ptc_event_callback(const ptc_cb_event_t eventType, cap_sensor_t* node) {
       tap_position_start = ADC1.RES;  // Store raw ADC value (no EWMA latency)
       tap_state = TAP_FIRST_PRESSED;
     } else if (tap_state == TAP_WAITING_FOR_DOUBLE) {
-      // Use raw ADC for immediate movement detection (no EWMA latency)
-      uint16_t current_adc = ADC1.RES;
-      uint16_t position_change = (current_adc > tap_position_start) ?
-                                  (current_adc - tap_position_start) :
-                                  (tap_position_start - current_adc);
-
       uint32_t now = millis();
-      if (now - tap_timestamp <= DOUBLE_TAP_MAX_INTERVAL && position_change <= TAP_MAX_MOVEMENT) {
+      if (now - tap_timestamp <= DOUBLE_TAP_MAX_INTERVAL &&
+          tap_position_delta() <= TAP_MAX_MOVEMENT) {
         tap_timestamp = now;
         tap_state = TAP_SECOND_PRESSED;
       } else {
@@ -1586,14 +2079,8 @@ void ptc_event_callback(const ptc_cb_event_t eventType, cap_sensor_t* node) {
       uint32_t now = millis();
       uint32_t tap_duration = now - tap_timestamp;
 
-      // Use raw ADC for immediate movement detection (no EWMA latency)
-      uint16_t current_adc = ADC1.RES;
-      uint16_t position_change = (current_adc > tap_position_start) ?
-                                  (current_adc - tap_position_start) :
-                                  (tap_position_start - current_adc);
-
       // Validate tap duration and movement
-      if (tap_duration <= TAP_MAX_DURATION && position_change <= TAP_MAX_MOVEMENT) {
+      if (tap_duration <= TAP_MAX_DURATION && tap_position_delta() <= TAP_MAX_MOVEMENT) {
         // Valid tap!
         if (tap_state == TAP_FIRST_PRESSED) {
           // First tap complete, wait for possible double-tap

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -76,228 +76,97 @@ enum TapState : uint8_t {
   TAP_SECOND_PRESSED,          // Second tap touch detected
 };
 
-// Fixed-rate control tick. The control law needs a known, constant period so
-// the derivative term and the filter time constants mean the same thing
-// regardless of how long touch processing takes on a given loop iteration.
+// Fixed-rate control tick, so gains and filter time constants keep the same
+// meaning regardless of how long touch processing takes on a given loop().
 #define CONTROL_TICK_US (500)           // 2 kHz (leaves loop headroom for touch)
 #define VELOCITY_TAU_S (0.004f)         // velocity estimate smoothing, seconds
 
-// Remote-movement control gains, in ADC counts (see MODEL notes below).
-// The plant is close to a velocity source with a friction deadband: above a
-// breakaway duty, speed is roughly proportional to duty; below it nothing
-// moves at all. Coast-down is first order with tau ~5 ms, so stopping distance
-// is ~v * 6 ms - which is why arriving at full speed overshoots by ~40 ADC
-// counts no matter how hard the bridge brakes afterwards.
-// The law is a cascade: the position loop sets a velocity reference, and the
-// velocity loop realises it. The old flat form (u = KP*e - KD*v + FF) was
-// already this - it factors exactly as FF + KD*((KP/KD)*e - v) - but written
-// flat it hid two things worth seeing:
-//
-//  - the inner loop's open-loop gain is k*KV, where k is the plant's ADC/s per
-//    duty. That, not KV alone, is what sets damping, so a higher-torque motor
-//    is a more aggressive loop. Through the lag of the velocity estimate it
-//    goes underdamped and the fader oscillates on velocity - overshoot, brake,
-//    re-accelerate. KV is therefore scaled by 1/k on a characterised unit.
-//  - the speed limit belongs on the reference, not bolted on as a governor
-//    that subtracts drive once the fader is already too fast.
-//
-// MOVE_VREF_SLOPE is the old KP/KD ratio and keeps its meaning: drive is cut
-// when the carriage is faster than slope*error, so the controller coasts the
-// last stretch. At 50/s against a measured 1/tau of ~200/s it cuts about four
-// stopping distances short, which also leaves roughly 2-2.5x margin on
-// effective moving mass (a heavier knob cap) before ringing returns.
+// Remote-movement control gains, in ADC counts. Cascade control: the position
+// loop turns error into a velocity reference (MOVE_VREF_SLOPE), the velocity
+// loop (MOVE_KV) realises it, and MOVE_BD_*/MOVE_K_DEFAULT feed forward the
+// plant's friction. See "The control law" in ABOUT_MOTOR_CONTROL.md for the
+// derivation and how these were tuned for hardware variance.
 #define MOVE_VREF_SLOPE (50.0f)         // ADC counts/sec of reference per ADC count of error
-#define MOVE_KV (0.04f)                 // duty per (ADC count/sec) of velocity error
-// Friction feedforward. The plant needs `breakaway` duty before it moves at
-// all, then gains `k` ADC counts/sec of speed per further duty count, so the
-// drive that produces a wanted speed is exactly
-//
-//     u_ff = breakaway + v_ref / k
-//
-// Expressing it this way rather than as one fixed number is what lets the
-// speed limit be honoured: a fixed feedforward commands whatever speed it
-// commands (~1100 ADC/s on the reference unit) and nothing below that is
-// reachable without subtracting drive back off again - which is what the old
-// one-sided governor did, and why it limit-cycled.
-//
-// The defaults below are the reference unit's plant, implied by the previous
-// fixed feedforward: FF 106/124 at k 29 is breakaway 68/86 plus 38 duty, and
-// 38 duty at k 29 is 1100 ADC/s. A characterised unit measures all of this.
+#define MOVE_KV (0.04f)                 // duty per (ADC count/sec) of velocity error; default only, scaled by 1/k when characterised
+// Friction feedforward: u_ff = breakaway + v_ref/k. Defaults are the
+// reference unit's measured plant; a characterised unit overrides them.
 #define MOVE_BD_RISING (68)             // assumed breakaway duty, rising ADC
 #define MOVE_BD_FALLING (86)            // assumed breakaway duty, falling ADC
 #define MOVE_K_DEFAULT (29)             // assumed ADC counts/sec per duty count
 #define MOVE_VJUMP_DEFAULT (448)        // assumed Stribeck jump; 1.25x it is MOVE_VEL_MIN
-// On-target window. This has a hard floor set by the plant, not by taste:
-// nothing moves below breakaway duty, and at breakaway speed jumps straight to
-// ~900 raw/s, so the smallest correction the fader can make is roughly that
-// speed times the reaction+stopping time - about 10-16 raw, i.e. 5-8 ADC
-// counts. A deadband below that floor cannot be satisfied on a fader whose
-// breakaway differs from the feedforward constants: the controller steps past
-// the window in both directions forever and eventually trips the movement
-// timeout. Keep this at or above the floor; it is ~1.5 LSB of the 8-bit
-// position the host sees, so tightening it buys nothing a host can observe.
+// On-target window. Has a hard floor set by the plant, not by taste - see
+// ABOUT_MOTOR_CONTROL.md. Don't lower it below the floor.
 #define MOVE_DEADBAND (8.0f)            // ADC counts considered "on target"
 #define MOVE_MAX_DUTY (254)
 
-// Optional speed limiting. Cruise velocity is already proportional to error
-// (the plant is a velocity source, so v ~ kv*KP*e / (1 + kv*KD)), which is why
-// big moves are fast and small ones are slow. Capping the error fed to the P
-// term therefore caps cruise speed, with no extra state and no motion profile.
-// Near the target the error is below the cap, so the clamp is inactive and the
-// tuned decel/coast/settle behaviour is untouched.
-//
-// This is a limit, not a precise speed: the constant below is the measured
-// closed-loop velocity per unit of error on the reference fader, and it varies
-// by ~20% between directions (friction is direction-dependent) plus unit to
-// unit. Callers wanting an exact velocity need a governor closing the loop on
-// measured velocity instead.
-// Implemented as a one-sided governor on measured velocity rather than by
-// clamping the error: the feedforward sits well above breakaway (deliberately,
-// for hardware tolerance), so it alone commands ~2200 raw counts/sec. Clamping
-// the error can only slow the fader to that floor, whereas subtracting from the
-// drive pulls it below the feedforward and reaches the real limit - the
-// Stribeck floor of ~900 raw counts/sec, below which the mechanism stick-slips
-// rather than moving smoothly.
-// Two cooperating parts are needed, and neither works alone:
-//  - the error clamp stops the P term saturating. For a large move KP*error is
-//    ~1300 duty, so the governor below cannot pull it under the 254 ceiling.
-//  - the governor pulls drive below the feedforward. The feedforward alone
-//    commands ~2200 raw counts/sec, so clamping the error can only slow the
-//    fader to that floor, never under it.
-// Slowest speed the mechanism sustains smoothly, and therefore the floor the
-// velocity reference is held at even right next to the target. Below roughly
-// this the motor cannot maintain continuous rotation (Stribeck friction) and
-// creeps in stick-slip steps instead. It doubles as the guarantee that the
-// feedforward stays clear of breakaway: the drive never falls below
-// breakaway + MOVE_VEL_MIN/k, so small errors still command real motion.
+// MOVE_VEL_MIN floors the velocity reference: below it the mechanism
+// stick-slips instead of moving smoothly (the Stribeck floor), and it's what
+// keeps the feedforward clear of breakaway when the error is small.
 #define MOVE_VEL_MIN (560)            // ADC counts/sec
-#define MOVE_VEL_UNLIMITED (0.0f)
+#define MOVE_VEL_UNLIMITED (0.0f)     // move_max_velocity: no speed limit requested
 
 // Endpoints of the host-facing unitless speed scale (LAYER_SPEED_SLOWEST ..
-// LAYER_SPEED_FULL - 1), expressed as the time a full-travel move takes. They
-// are the ends of the range the limiter was actually measured over: below
-// MOVE_SPEED_SLOWEST_MS tracking falls apart as the governor runs into the
-// Stribeck floor, and above MOVE_SPEED_FASTEST_MS the limit sits at or beyond
-// what the unlimited controller already does, so it stops having any effect.
-// Mapping the whole byte onto this window means every value a host can send
-// does something, rather than most of the range being unusable.
+// LAYER_SPEED_FULL - 1), as the full-travel time at each end - the validated
+// range of the speed limiter. See "Optional speed limiting" in
+// ABOUT_MOTOR_CONTROL.md.
 #define MOVE_SPEED_SLOWEST_MS (700)
 #define MOVE_SPEED_FASTEST_MS (250)
 
-// On movement timeout, an error this small means the fader is essentially in
-// position and merely hunting - give up quietly rather than latching
-// MODE_ERROR, which needs a host round-trip to clear. Anything larger is a
-// genuine fault and still errors.
+// On movement timeout, an error below this means the fader arrived but is
+// still dithering - go idle instead of latching MODE_ERROR.
 #define MOVE_TIMEOUT_TOLERANCE (20.0f)  // ADC counts
 
-// Stiction ramp. The feedforward alone leaves a dead region: for small errors
-// FF + KP*error can sit below this unit's actual breakaway duty, so the
-// controller commands motion it cannot produce and the move never completes
-// (previously this timed out into MODE_ERROR). Rather than raise the
-// feedforward - which overshoots on a looser fader, since anything above
-// breakaway jumps straight to ~900 raw counts/sec - ramp in extra drive only
-// while we are asking for motion and not getting it, and drop it the moment
-// the carriage breaks free. This finds whatever breakaway a given fader has
-// instead of relying on a per-unit constant.
+// Stiction ramp: extra drive added while commanded to move but stalled, so a
+// unit whose breakaway sits above the feedforward can still complete a move.
 #define MOVE_STALL_VELOCITY (60.0f)     // ADC counts/sec below which we're stalled
 #define MOVE_RAMP_RATE (250.0f)         // duty per second of ramp-in
 #define MOVE_RAMP_MAX (70.0f)           // ceiling, so a jam can't wind up to full drive
 #define MOVE_RAMP_DECAY_RATE (3500.0f)  // duty/sec shed once moving (~20 ms from full)
 
-// Backlash take-up. There is a little slack in the belt, so a move that
-// reverses direction starts with the motor unloaded. Commanding full duty into
-// that slack lets the rotor spin up freely and then snap taut, which is both an
-// audible click and a jerk at the carriage. While we are still stalled the
-// drive is therefore capped just above breakaway: enough to cross the slack
-// promptly, but slow enough that engagement is gentle. Full authority returns
-// as soon as the carriage is actually moving, so this costs only a few ms.
-// Backlash take-up. A direction-reversed move starts with the motor unloaded,
-// so commanding full duty lets the rotor spin up through the slack and snap it
-// taut - an audible click and a jerk at the carriage. The drive ceiling
-// therefore starts low at the beginning of every move and opens up over time.
-//
-// This is deliberately time-based rather than gated on "are we moving yet":
-// while crossing the slack the rotor IS moving (it just isn't loaded), so a
-// velocity-gated ceiling lifts partway through the slack and full duty still
-// lands on engagement. Time is the only signal available that does not depend
-// on whether the belt has taken up yet.
-// MUST stay above MOVE_FF_RISING/FALLING. The ceiling exists to stop the drive
-// stepping to full duty, not to suppress the feedforward: set below FF it
-// starves the very term that gets the carriage moving, so the fader stalls,
-// waits for the stiction ramp, and breaks free abruptly - which both hunts and
-// makes the click worse rather than better.
+// Backlash take-up: a direction-reversed move starts with the motor
+// unloaded, so full duty would spin the rotor through the belt slack and
+// snap it taut - an audible click and a jerk. The drive ceiling instead
+// starts low at the beginning of every move and opens up over time (this has
+// to be time-based, not "are we moving yet", since crossing the slack the
+// rotor is already moving but unloaded). Must stay above the feedforward
+// (MOVE_BD_RISING/FALLING plus headroom) or it starves the term that gets
+// the carriage moving.
 #define MOVE_TAKEUP_DUTY (130)           // duty ceiling at the start of a move
 #define MOVE_TAKEUP_RAMP_RATE (1200.0f)  // duty per second the ceiling opens up
 
 // ---------------------------------------------------------------------------
 // Per-unit motor characterisation
 // ---------------------------------------------------------------------------
-// Self-calibration measures three things about this specific motor, in each
-// direction, and the gains above are re-derived from them:
+// Self-calibration measures three things about this motor, per direction, and
+// the gains above are re-derived from them (apply_motor_calibration):
 //
 //   breakaway  the duty at which the carriage first moves at all
 //   k          ADC counts/sec of cruise gained per duty count above breakaway
 //   v_jump     the speed motion starts at the instant breakaway is crossed
 //
-// Why this is worth doing rather than picking better constants: the smallest
-// correction the controller can command near the target is roughly
-//
-//   v_min = k * (KP*deadband + FF - breakaway) / (1 + k*KD)
-//
-// and it can only settle if v_min * (stopping time) fits inside the deadband.
-// FF is a fixed duty, so on a unit whose breakaway is well BELOW the value FF
-// was centred on, (FF - breakaway) is large, v_min is high, and the carriage
-// physically cannot land inside the window - it steps past in both directions
-// until the movement timeout. That is the low-stiction failure, and it is the
-// mirror image of the high-stiction one the stiction ramp already handles.
-// Measuring breakaway makes (FF - breakaway) a designed quantity rather than
-// an accident of which fader is fitted.
-//
-// k is what turns a wanted speed into a duty, so it appears twice in the
-// control law: in the feedforward (breakaway + v_ref/k) and in the velocity
-// loop gain, which is scaled by 1/k so the loop's open-loop gain k*KV - the
-// thing that actually sets damping - is the same on every unit.
+// See "Per-unit motor characterisation" in ABOUT_MOTOR_CONTROL.md for why a
+// fixed set of gains can't serve every unit and how these are derived.
 
 // Target open-loop gain for the velocity loop, k*KV, held constant across
-// units by scaling KV with 1/k. 1.16 is what the reference unit ran at
-// (k 29, KV 0.04) and settles cleanly; higher rings through the lag of the
-// velocity estimate, lower is sluggish and lets the feedforward's own error
-// show up as steady-state speed droop.
+// units by scaling KV with 1/k. 1.16 is what the reference unit ran at.
 #define MOTORCAL_KV_LOOP_GAIN (1.16f)
 
-// Floor and ceiling on the derived reference floor (1.25x the Stribeck jump).
+// Bounds on the derived velocity floor (1.25x the Stribeck jump).
 #define MOTORCAL_VEL_MIN_LO (200)
 #define MOTORCAL_VEL_MIN_HI (1500)
 
-// How long it takes to actually stop, measured from the carriage reaching the
-// window rather than from drive being cut. This is NOT the coast time alone:
-// the position filter and the control tick both have to notice first, and the
-// carriage keeps travelling throughout. Coast-down is first order with tau
-// ~5 ms (so ~6 ms of travel), but the reference unit's measured minimum
-// correction of 5-8 ADC counts at 450-560 ADC/s implies 9-18 ms end to end.
-//
-// Getting this wrong is the expensive direction: too small a deadband cannot
-// be satisfied at all, so the fader steps past the window in both directions
-// indefinitely and dithers until the movement timeout. Too large just means a
-// slightly less accurate final position, which is worth well under an LSB of
-// what the host can see. Size it for the pessimistic end.
-#define MOTORCAL_STOP_TIME_MS (15)       // reaction + detection + coast, ms
+// Time from the carriage reaching the deadband to actually stopping -
+// reaction + detection + coast, not coast alone (see ABOUT_MOTOR_CONTROL.md).
+#define MOTORCAL_STOP_TIME_MS (15)       // ms
 #define MOTORCAL_TAKEUP_MARGIN (20)      // take-up ceiling sits this far above FF
-// Bounds on the derived on-target window. The floor is the reference unit's
-// validated value; the ceiling is a backstop against an implausible v_jump
-// measurement, not a judgement that a wider window would be wrong.
+// Bounds on the derived on-target window.
 #define MOTORCAL_DEADBAND_LO (8)         // ADC counts
 #define MOTORCAL_DEADBAND_HI (20)
 
-// Measurement procedure. Each run parks at one end, ramps duty until motion
-// starts, then dwells at two fixed duties above breakaway to get a two-point
-// fit for k. Runs alternate direction, so each one starts where the previous
-// one left off and only the first needs a long park.
+// Measurement procedure: park, ramp to breakaway, then dwell at two duties
+// above breakaway for a two-point fit of k. Runs alternate direction, so each
+// one starts where the previous one left off.
 #define MOTORCAL_PASSES (2)              // runs per direction, averaged
-// Ramp rate trades calibration time against breakaway resolution. Detection
-// latency is set by the velocity filter (~5 ms), not by the ramp, so 80 duty/s
-// still resolves breakaway to well under a duty count while keeping a full
-// calibration under ~10 s.
 #define MOTORCAL_RAMP_RATE (80.0f)       // duty/sec
 #define MOTORCAL_RAMP_MAX (200.0f)       // give up: this unit has no usable breakaway
 #define MOTORCAL_MOTION_VEL (200.0f)     // ADC counts/sec that counts as "moving"
@@ -312,8 +181,8 @@ enum TapState : uint8_t {
 #define MOTORCAL_PARK_TIMEOUT (2500)     // ms
 #define MOTORCAL_EDGE_MARGIN (25)        // abort if a run gets this close to an end
 
-// Plausibility bounds. Anything outside these means the measurement, not the
-// fader, is wrong - fall back to the compiled defaults rather than trusting it.
+// Plausibility bounds - outside these, the measurement (not the fader) is
+// wrong, so fall back to the compiled defaults.
 #define MOTORCAL_BD_MIN (10)
 #define MOTORCAL_BD_MAX (180)
 #define MOTORCAL_K_MIN (8)
@@ -321,19 +190,13 @@ enum TapState : uint8_t {
 #define MOTORCAL_VJUMP_MIN (100)
 #define MOTORCAL_VJUMP_MAX (4000)
 
-// The MOVE_* constants above are the DEFAULTS, used by a unit that has never
-// been motor-calibrated. They are not the gains the controller runs: every one
-// of them is really a statement about this unit's friction and torque written
-// in absolute duty, so self-calibration measures those two things directly and
-// derives the live values below (see apply_motor_calibration). A fader whose
-// breakaway or torque differs materially from the reference unit the constants
-// were centred on cannot be served by any single set of numbers - see
-// "Tuning for hardware variance" in ABOUT_MOTOR_CONTROL.md.
+// The MOVE_* constants above are defaults for a unit that has never been
+// motor-calibrated; apply_motor_calibration() derives the live values below
+// from a real measurement when one exists.
 //
 // DEBUG_DRIVE builds additionally let a host overwrite these at runtime via
 // REG_DEBUG_GAINS, so a gain sweep doesn't need a reflash per trial.
-// Plant model and gains in use, indexed [MOTORCAL_FALLING]/[MOTORCAL_RISING]
-// where per-direction. Defaults until a unit is characterised.
+// Indexed [MOTORCAL_FALLING]/[MOTORCAL_RISING] where per-direction.
 float move_bd[2];                                          // breakaway duty
 float move_inv_k[2];                                       // duty per (ADC/s)
 float move_kv = MOVE_KV;                                   // velocity loop gain
@@ -381,12 +244,9 @@ const uint8_t I2C_BASE_ADDRESS = 0x20;
 #define EEPROM_CALIBRATION_ADDR 0
 #define EEPROM_CALIBRATION_MAGIC 0xCAF1  // Magic number to validate EEPROM data
 
-// Motor characterisation, as measured and as reported at REG_MOTOR_CAL.
-// Held separately from the derived gains so the raw measurement stays
-// inspectable - if a fader misbehaves, these are the numbers worth seeing.
-// Indexed by direction of travel throughout - [MOTORCAL_FALLING] and
-// [MOTORCAL_RISING] - so the measurement, the derivation and the accumulators
-// all address it the same way instead of each carrying its own pair of cases.
+// Motor characterisation, as measured and reported at REG_MOTOR_CAL. Held
+// separately from the derived gains so the raw measurement stays inspectable.
+// Indexed by direction of travel throughout: [MOTORCAL_FALLING]/[MOTORCAL_RISING].
 #define MOTORCAL_FALLING (0)
 #define MOTORCAL_RISING (1)
 
@@ -845,21 +705,12 @@ void onI2cReceive(int howMany) {
 
 // Re-derive the live control gains from this unit's measured motor
 // characteristics, or restore the compiled-in defaults when no valid
-// measurement exists. Safe to call at any time; it only touches gains.
-//
-// Everything here is a restatement of the MOVE_* defaults in terms of the
-// plant rather than in absolute duty:
-//   FF       = breakaway + (a fixed SPEED of headroom), not a fixed duty
-//   KP, KD   = scaled by k_ref/k, holding the real loop gains KP*k and KD*k
-//              constant, and with them the KP/KD ratio the coast-in relies on
-//   deadband = at least the distance covered by this unit's Stribeck jump
-//   take-up  = above FF, which is an invariant of the take-up ceiling
-// At the reference unit's measurements this reproduces the shipped values.
+// measurement exists. Safe to call at any time; it only touches gains. See
+// "What is derived" in ABOUT_MOTOR_CONTROL.md for the formulas.
 void apply_motor_calibration() {
   // The compiled-in defaults are themselves a plant model - the reference
-  // unit's - so there is one derivation, not one per case. That is not just
-  // tidiness: it guarantees an uncharacterised fader runs exactly the gains
-  // the constants were tuned to, because they are computed the same way.
+  // unit's - so there is one derivation, not one per case: an uncharacterised
+  // fader runs exactly the gains the constants were tuned to.
   uint8_t bd[2], k[2];
   uint16_t vjump;
   if (motor_cal.valid) {
@@ -1308,26 +1159,10 @@ void motor_update() {
         }
         float error = target_adc - input_ewma;
         if (error > move_deadband || error < -move_deadband) {
-          // Cascade control. The position loop asks for a velocity, the
-          // velocity loop delivers it:
-          //
-          //   v_ref = clamp(slope * error, floor .. speed limit)
-          //   u     = breakaway + v_ref/k          (feedforward)
-          //         + KV * (v_ref - v)             (feedback)
-          //
-          // The feedforward is the plant model inverted, so at steady state the
-          // feedback term is zero and the fader simply travels at v_ref. That
-          // is what makes the speed limit a limit rather than a fight: the old
-          // law carried a fixed feedforward that commanded ~1100 ADC/s no
-          // matter what was asked for, and needed a one-sided governor to
-          // subtract drive back off once the fader was already too fast. A
-          // one-sided correction with the operating point sitting exactly on
-          // its discontinuity is a limit-cycle generator, and it behaved like
-          // one: overshoot the limit, brake, fall under, accelerate again.
-          //
-          // Clamping the reference instead keeps one well-damped loop in charge
-          // at every speed, and the same clamp replaces the separate P-term
-          // error clamp the governor needed to stop KP saturating.
+          // Cascade control: the position loop turns error into a velocity
+          // reference, the velocity loop delivers it via feedforward (plant
+          // inverted) plus feedback. See "The control law" in
+          // ABOUT_MOTOR_CONTROL.md for the derivation.
           float v_ref = move_vref_slope * error;
           float mag = v_ref < 0 ? -v_ref : v_ref;
           if (move_max_velocity > MOVE_VEL_UNLIMITED && mag > move_max_velocity) {

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -501,6 +501,9 @@ void onI2cRequest() {
   uint8_t r = current_register;
   if (r == REG_VERSION) {
       Wire.write(I2C_PROTOCOL_VERSION);
+  } else if (r == REG_FW_VERSION) {
+      Wire.write((FW_VERSION >> 8) & 0xFF);
+      Wire.write(FW_VERSION & 0xFF);
   } else if (r == REG_STATE) {
       // Snapshot once: the main loop can update i2c_outgoing_state between
       // byte writes, which would hand the controller a torn value.
@@ -643,6 +646,7 @@ void onI2cReceive(int howMany) {
       break;
 #endif
     case REG_VERSION:
+    case REG_FW_VERSION:
     case REG_STATE:
     case REG_UPTIME:
     case REG_TOUCH_RAW:

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -21,10 +21,8 @@
 
 #include "shared/i2c_data.h"
 #include "util.h"
-
-
-
-#define DEMO 0
+#include "motor_cal.h"
+#include "motor_control.h"
 
 #define PIN_LED (PIN_PB2)
 #define LED_bm (1 << 2)  // PIN_LED on VPORTB, for direct port access
@@ -44,7 +42,6 @@
 #define PIN_ADDR_0 (PIN_PC2)
 #define PIN_ADDR_1 (PIN_PC1)
 #define PIN_ADDR_2 (PIN_PC0)
-
 
 // PWM configuration
 #if defined(MILLIS_USE_TIMERA0) || defined(__AVR_ATtinyxy2__)
@@ -81,125 +78,12 @@ enum TapState : uint8_t {
 #define CONTROL_TICK_US (500)           // 2 kHz (leaves loop headroom for touch)
 #define VELOCITY_TAU_S (0.004f)         // velocity estimate smoothing, seconds
 
-// Remote-movement control gains, in ADC counts. Cascade control: the position
-// loop turns error into a velocity reference (MOVE_VREF_SLOPE), the velocity
-// loop (MOVE_KV) realises it, and MOVE_BD_*/MOVE_K_DEFAULT feed forward the
-// plant's friction. See "The control law" in ABOUT_MOTOR_CONTROL.md for the
-// derivation and how these were tuned for hardware variance.
-#define MOVE_VREF_SLOPE (50.0f)         // ADC counts/sec of reference per ADC count of error
-#define MOVE_KV (0.04f)                 // duty per (ADC count/sec) of velocity error; default only, scaled by 1/k when characterised
-// Friction feedforward: u_ff = breakaway + v_ref/k. Defaults are the
-// reference unit's measured plant; a characterised unit overrides them.
-#define MOVE_BD_RISING (68)             // assumed breakaway duty, rising ADC
-#define MOVE_BD_FALLING (86)            // assumed breakaway duty, falling ADC
-#define MOVE_K_DEFAULT (29)             // assumed ADC counts/sec per duty count
-#define MOVE_VJUMP_DEFAULT (448)        // assumed Stribeck jump; 1.25x it is MOVE_VEL_MIN
-// On-target window. Has a hard floor set by the plant, not by taste - see
-// ABOUT_MOTOR_CONTROL.md. Don't lower it below the floor.
-#define MOVE_DEADBAND (8.0f)            // ADC counts considered "on target"
-#define MOVE_MAX_DUTY (254)
-
-// MOVE_VEL_MIN floors the velocity reference: below it the mechanism
-// stick-slips instead of moving smoothly (the Stribeck floor), and it's what
-// keeps the feedforward clear of breakaway when the error is small.
-#define MOVE_VEL_MIN (560)            // ADC counts/sec
-#define MOVE_VEL_UNLIMITED (0.0f)     // move_max_velocity: no speed limit requested
-
-// Endpoints of the host-facing unitless speed scale (LAYER_SPEED_SLOWEST ..
-// LAYER_SPEED_FULL - 1), as the full-travel time at each end - the validated
-// range of the speed limiter. See "Optional speed limiting" in
-// ABOUT_MOTOR_CONTROL.md.
-#define MOVE_SPEED_SLOWEST_MS (700)
-#define MOVE_SPEED_FASTEST_MS (250)
-
-// On movement timeout, an error below this means the fader arrived but is
-// still dithering - go idle instead of latching MODE_ERROR.
-#define MOVE_TIMEOUT_TOLERANCE (20.0f)  // ADC counts
-
-// Stiction ramp: extra drive added while commanded to move but stalled, so a
-// unit whose breakaway sits above the feedforward can still complete a move.
-#define MOVE_STALL_VELOCITY (60.0f)     // ADC counts/sec below which we're stalled
-#define MOVE_RAMP_RATE (250.0f)         // duty per second of ramp-in
-#define MOVE_RAMP_MAX (70.0f)           // ceiling, so a jam can't wind up to full drive
-#define MOVE_RAMP_DECAY_RATE (3500.0f)  // duty/sec shed once moving (~20 ms from full)
-
-// Backlash take-up: a direction-reversed move starts with the motor
-// unloaded, so full duty would spin the rotor through the belt slack and
-// snap it taut - an audible click and a jerk. The drive ceiling instead
-// starts low at the beginning of every move and opens up over time (this has
-// to be time-based, not "are we moving yet", since crossing the slack the
-// rotor is already moving but unloaded). Must stay above the feedforward
-// (MOVE_BD_RISING/FALLING plus headroom) or it starves the term that gets
-// the carriage moving.
-#define MOVE_TAKEUP_DUTY (130)           // duty ceiling at the start of a move
-#define MOVE_TAKEUP_RAMP_RATE (1200.0f)  // duty per second the ceiling opens up
-
-// ---------------------------------------------------------------------------
-// Per-unit motor characterisation
-// ---------------------------------------------------------------------------
-// Self-calibration measures three things about this motor, per direction, and
-// the gains above are re-derived from them (apply_motor_calibration):
-//
-//   breakaway  the duty at which the carriage first moves at all
-//   k          ADC counts/sec of cruise gained per duty count above breakaway
-//   v_jump     the speed motion starts at the instant breakaway is crossed
-//
-// See "Per-unit motor characterisation" in ABOUT_MOTOR_CONTROL.md for why a
-// fixed set of gains can't serve every unit and how these are derived.
-
-// Target open-loop gain for the velocity loop, k*KV, held constant across
-// units by scaling KV with 1/k. 1.16 is what the reference unit ran at.
-#define MOTORCAL_KV_LOOP_GAIN (1.16f)
-
-// Bounds on the derived velocity floor (1.25x the Stribeck jump).
-#define MOTORCAL_VEL_MIN_LO (200)
-#define MOTORCAL_VEL_MIN_HI (1500)
-
-// Time from the carriage reaching the deadband to actually stopping -
-// reaction + detection + coast, not coast alone (see ABOUT_MOTOR_CONTROL.md).
-#define MOTORCAL_STOP_TIME_MS (15)       // ms
-#define MOTORCAL_TAKEUP_MARGIN (20)      // take-up ceiling sits this far above FF
-// Bounds on the derived on-target window.
-#define MOTORCAL_DEADBAND_LO (8)         // ADC counts
-#define MOTORCAL_DEADBAND_HI (20)
-
-// Measurement procedure: park, ramp to breakaway, then dwell at two duties
-// above breakaway for a two-point fit of k. Runs alternate direction, so each
-// one starts where the previous one left off.
-#define MOTORCAL_PASSES (2)              // runs per direction, averaged
-#define MOTORCAL_RAMP_RATE (80.0f)       // duty/sec
-#define MOTORCAL_RAMP_MAX (200.0f)       // give up: this unit has no usable breakaway
-#define MOTORCAL_MOTION_VEL (200.0f)     // ADC counts/sec that counts as "moving"
-#define MOTORCAL_JUMP_MS (40)            // window for capturing the Stribeck jump
-#define MOTORCAL_DWELL_A (25)            // duty above breakaway, first fit point
-#define MOTORCAL_DWELL_B (50)            // duty above breakaway, second fit point
-#define MOTORCAL_DWELL_MS (100)          // hold per fit point
-#define MOTORCAL_DWELL_AVG_MS (50)       // average over the last part of the hold
-#define MOTORCAL_SETTLE_MS (200)         // coast to a stop before ramping
-#define MOTORCAL_PARK_MARGIN (60)        // ADC counts from the end to start a run
-#define MOTORCAL_PARK_DUTY (200)         // open-loop duty used to park
-#define MOTORCAL_PARK_TIMEOUT (2500)     // ms
-#define MOTORCAL_EDGE_MARGIN (25)        // abort if a run gets this close to an end
-
-// Plausibility bounds - outside these, the measurement (not the fader) is
-// wrong, so fall back to the compiled defaults.
-#define MOTORCAL_BD_MIN (10)
-#define MOTORCAL_BD_MAX (180)
-#define MOTORCAL_K_MIN (8)
-#define MOTORCAL_K_MAX (90)
-#define MOTORCAL_VJUMP_MIN (100)
-#define MOTORCAL_VJUMP_MAX (4000)
-
-// The MOVE_* constants above are defaults for a unit that has never been
-// motor-calibrated; apply_motor_calibration() derives the live values below
-// from a real measurement when one exists.
-//
-// DEBUG_DRIVE builds additionally let a host overwrite these at runtime via
-// REG_DEBUG_GAINS, so a gain sweep doesn't need a reflash per trial.
-// Indexed [MOTORCAL_FALLING]/[MOTORCAL_RISING] where per-direction.
-float move_bd[2];                                          // breakaway duty
-float move_inv_k[2];                                       // duty per (ADC/s)
-float move_kv = MOVE_KV;                                   // velocity loop gain
+// Live gains - declared in motor_control.h, derived by motor_cal.cpp, defined
+// here alongside the control law that consumes them. DEBUG_DRIVE builds let a
+// host overwrite them at runtime via REG_DEBUG_GAINS.
+float move_bd[2];
+float move_inv_k[2];
+float move_kv = MOVE_KV;
 int16_t move_takeup_duty = MOVE_TAKEUP_DUTY;
 float move_deadband = MOVE_DEADBAND;
 float move_vel_min = MOVE_VEL_MIN;
@@ -218,7 +102,8 @@ const float ALPHA = 0.05;
 float input_ewma = 0;
 float stiction_ramp = 0;                // extra drive ramped in while stalled
 float move_max_velocity = MOVE_VEL_UNLIMITED;  // 0 = unlimited
-float drive_ceiling = MOVE_MAX_DUTY;    // take-up ceiling, reset at each move start
+float drive_ceiling = MOVE_MAX_DUTY;    // take-up ceiling, re-armed on direction change
+int8_t move_direction = 0;              // commanded direction of the move in progress
 float velocity_ewma = 0;                // ADC counts/sec, + toward the motor end
 float last_control_ewma = 0;
 uint32_t last_control_tick_us = 0;
@@ -231,7 +116,6 @@ uint16_t control_tick_period_us = CONTROL_TICK_US;  // runtime-tunable for sweep
 #endif
 
 // Touch state
-bool touch = false;
 cap_sensor_t touch_sensor;
 uint16_t touch_recal_count = 0;  // Count of touch recalibrations since boot
 
@@ -244,19 +128,6 @@ const uint8_t I2C_BASE_ADDRESS = 0x20;
 #define EEPROM_CALIBRATION_ADDR 0
 #define EEPROM_CALIBRATION_MAGIC 0xCAF1  // Magic number to validate EEPROM data
 
-// Motor characterisation, as measured and reported at REG_MOTOR_CAL. Held
-// separately from the derived gains so the raw measurement stays inspectable.
-// Indexed by direction of travel throughout: [MOTORCAL_FALLING]/[MOTORCAL_RISING].
-#define MOTORCAL_FALLING (0)
-#define MOTORCAL_RISING (1)
-
-struct MotorCalData {
-  uint8_t valid;      // 0 = never measured, or measured implausibly
-  uint8_t bd[2];      // breakaway duty
-  uint8_t k[2];       // ADC counts/sec per duty above breakaway
-  uint16_t vjump[2];  // ADC counts/sec at the moment motion starts
-};
-
 struct CalibrationData {
   uint16_t magic;         // Magic number for validation
   uint16_t calib_min;     // Minimum ADC value (fader at one end)
@@ -267,14 +138,12 @@ struct CalibrationData {
 
 uint16_t input_calib_min = 40;
 uint16_t input_calib_max = 1010;
-MotorCalData motor_cal = {0, {0, 0}, {0, 0}, {0, 0}};
 
 int16_t target_adc = 512;
 uint8_t current_register = REG_VERSION;  // Track which register was last accessed
 
 // Haptic configuration storage
 uint32_t haptic_config = 0;  // Bit-packed haptic configuration register (currently active layer's config)
-uint8_t last_haptic_nonce = 0;  // Track last seen nonce to detect changes [DEPRECATED in v5]
 
 // Layer state storage (27 bytes total) - Protocol v5+
 uint16_t layer_haptic_configs[8];      // 16 bytes - 16-bit haptic config per layer
@@ -366,48 +235,6 @@ uint32_t tap_timestamp = 0;          // Timestamp of last tap-related event for 
 uint16_t tap_position_start = 0;     // Raw ADC value when first touch started
 uint8_t double_tap_nonce = 0;
 
-uint32_t self_calibration_start = 0;
-uint8_t self_calibration_stage = 0;
-#define SELF_CALIBRATION_TIMEOUT (1500)
-#define SELF_CALIBRATION_BUFFER (0.995)  // Buffer factor to prevent hitting physical limits
-uint16_t self_calibration_adc_stage_0 = 0;
-uint16_t self_calibration_adc_stage_1 = 0;
-
-// Self-calibration runs the endpoint sweep first, then characterises the motor
-// (see the MOTORCAL_* constants). Stages 0-2 are the original endpoint sweep;
-// their numbering is unchanged.
-enum SelfCalStage : uint8_t {
-  SELFCAL_ENDPOINT_LOW = 0,   // drive to the low end, record it
-  SELFCAL_ENDPOINT_HIGH,      // drive to the high end, record it
-  SELFCAL_ENDPOINT_APPLY,     // validate the span, adopt it in RAM
-  SELFCAL_MOTOR_PARK,         // drive to the end this run starts from
-  SELFCAL_MOTOR_SETTLE,       // coast to a genuine stop before measuring
-  SELFCAL_MOTOR_RAMP,         // ramp to breakaway, then hold and capture the jump
-  SELFCAL_MOTOR_DWELL_A,      // hold breakaway + A, measure cruise speed
-  SELFCAL_MOTOR_DWELL_B,      // hold breakaway + B, measure cruise speed
-  SELFCAL_MOTOR_NEXT,         // fold in the run, advance or finish
-  SELFCAL_FINISH,             // derive gains, persist, return to the target
-};
-
-// Motor characterisation working state. Runs alternate direction starting with
-// falling (the endpoint sweep leaves the carriage at the high end), so each run
-// begins where the previous one ended.
-uint8_t motorcal_run = 0;          // 0..2*MOTORCAL_PASSES-1; even falling, odd rising
-bool motorcal_failed = false;
-uint16_t motorcal_duty = 0;        // ramped duty, fixed point (1/64 duty per LSB)
-int16_t motorcal_bd = 0;           // breakaway duty found by this run
-int16_t motorcal_vjump = 0;        // peak speed just after breakaway, ADC/s
-int16_t motorcal_dwell_a = 0;      // cruise speed at breakaway + A, ADC/s
-int32_t motorcal_vel_sum = 0;      // dwell velocity accumulator
-uint16_t motorcal_vel_n = 0;
-// Per-direction accumulators, indexed [0] = falling, [1] = rising. Integer,
-// because flash is the scarce resource on this part and a duty count or an
-// ADC count/sec is all the resolution any of these needs.
-uint16_t motorcal_bd_sum[2] = {0, 0};
-uint16_t motorcal_k_sum[2] = {0, 0};
-uint16_t motorcal_vjump_max[2] = {0, 0};
-uint8_t motorcal_samples[2] = {0, 0};
-
 bool pending_report_on_idle = false;
 
 bool pending_calibrate_touch = false;
@@ -428,12 +255,13 @@ Mode get_mode() {
 void set_mode(Mode mode) {
   state = (state & ~STATE_MODE_bm) | (mode << STATE_MODE_bp);
 
-  // Any fresh movement starts without accumulated stiction ramp, and with the
-  // drive ceiling back down so backlash is taken up gently.
   if (mode != MODE_REMOTE_MOVEMENT_IN_PROGRESS) {
+    // Any fresh movement starts without accumulated stiction ramp.
     stiction_ramp = 0;
   } else {
-    drive_ceiling = move_takeup_duty;
+    // A commanded move is not local input, so drop any pending position-nonce
+    // report - the host must not see the echo of its own command as a user move.
+    pending_report_on_idle = false;
   }
 
   // Reset tap detection when entering modes where taps shouldn't be detected
@@ -445,15 +273,9 @@ void set_mode(Mode mode) {
 // ============================================================================
 // Motor drive
 // ============================================================================
-// PA4 = Motor A (WO4/HCMP1), PA5 = Motor B (WO5/HCMP2). Both feed the DRV8837
-// IN1/IN2 inputs: 1/0 = forward, 0/1 = reverse, 0/0 = coast (Hi-Z), 1/1 = brake.
+// Declared in motor_control.h, which carries the bridge's truth table.
 #define MOTOR_A_bm (1 << 4)
 #define MOTOR_B_bm (1 << 5)
-
-enum MotorIdle : uint8_t {
-  MOTOR_IDLE_COAST = 0,  // Bridge Hi-Z: fader is free to move
-  MOTOR_IDLE_BRAKE = 1,  // Both low sides on: dynamic braking against motion
-};
 
 int16_t motor_drive_value = 0;  // Last applied signed drive, for status/LED
 
@@ -506,6 +328,12 @@ void motor_set(int16_t drive, bool slow_decay, MotorIdle idle_mode) {
     }
   }
 }
+
+// At zero drive both the decay mode and the duty are irrelevant, so these two
+// are the whole vocabulary of "stop": coast leaves the fader free to move,
+// brake holds it against motion.
+void motor_coast() { motor_set(0, false, MOTOR_IDLE_COAST); }
+void motor_brake() { motor_set(0, false, MOTOR_IDLE_BRAKE); }
 
 // Configure TCA0 for a single, permanently inaudible PWM carrier.
 // Movement used to drop to DIV256 (306 Hz) because at 19.6 kHz with drive/coast
@@ -703,69 +531,6 @@ void onI2cReceive(int howMany) {
 
 }
 
-// Re-derive the live control gains from this unit's measured motor
-// characteristics, or restore the compiled-in defaults when no valid
-// measurement exists. Safe to call at any time; it only touches gains. See
-// "What is derived" in ABOUT_MOTOR_CONTROL.md for the formulas.
-void apply_motor_calibration() {
-  // The compiled-in defaults are themselves a plant model - the reference
-  // unit's - so there is one derivation, not one per case: an uncharacterised
-  // fader runs exactly the gains the constants were tuned to.
-  uint8_t bd[2], k[2];
-  uint16_t vjump;
-  if (motor_cal.valid) {
-    bd[MOTORCAL_FALLING] = motor_cal.bd[MOTORCAL_FALLING];
-    bd[MOTORCAL_RISING] = motor_cal.bd[MOTORCAL_RISING];
-    k[MOTORCAL_FALLING] = motor_cal.k[MOTORCAL_FALLING];
-    k[MOTORCAL_RISING] = motor_cal.k[MOTORCAL_RISING];
-    vjump = (motor_cal.vjump[0] > motor_cal.vjump[1]) ? motor_cal.vjump[0]
-                                                      : motor_cal.vjump[1];
-  } else {
-    bd[MOTORCAL_FALLING] = MOVE_BD_FALLING;
-    bd[MOTORCAL_RISING] = MOVE_BD_RISING;
-    k[MOTORCAL_FALLING] = MOVE_K_DEFAULT;
-    k[MOTORCAL_RISING] = MOVE_K_DEFAULT;
-    vjump = MOVE_VJUMP_DEFAULT;
-  }
-
-  // The Stribeck jump is the slowest the mechanism moves at all, so it floors
-  // both the velocity reference and the on-target window: the fader cannot
-  // correct by less than the distance it covers before it can be stopped.
-  uint16_t vel_min = vjump + vjump / 4;  // 1.25x, for margin above the floor
-  if (vel_min < MOTORCAL_VEL_MIN_LO) vel_min = MOTORCAL_VEL_MIN_LO;
-  if (vel_min > MOTORCAL_VEL_MIN_HI) vel_min = MOTORCAL_VEL_MIN_HI;
-  move_vel_min = vel_min;
-
-  uint16_t deadband = (uint16_t)(((uint32_t)vel_min * MOTORCAL_STOP_TIME_MS + 500) / 1000);
-  if (deadband < MOTORCAL_DEADBAND_LO) deadband = MOTORCAL_DEADBAND_LO;
-  if (deadband > MOTORCAL_DEADBAND_HI) deadband = MOTORCAL_DEADBAND_HI;
-  move_deadband = deadband;
-
-  // Take-up ceiling: limits drive at the start of a move so the belt is not
-  // engaged at full duty. It has to stay above the feedforward at the floor
-  // speed, or it starves the term that gets the carriage moving. Integer
-  // arithmetic deliberately - this runs once, but flash is permanent.
-  int16_t takeup = MOVE_TAKEUP_DUTY;
-  for (uint8_t i = 0; i < 2; i++) {
-    int16_t ff = bd[i] + (int16_t)(vel_min / (k[i] ? k[i] : 1)) + MOTORCAL_TAKEUP_MARGIN;
-    if (ff > takeup) takeup = ff;
-  }
-  if (takeup > MOVE_MAX_DUTY) takeup = MOVE_MAX_DUTY;
-  move_takeup_duty = takeup;
-
-  // The only float work: the control law needs 1/k per direction for the
-  // feedforward, and the velocity loop gain scaled so its open-loop gain k*KV
-  // - the thing that actually sets damping - matches the reference unit's.
-  uint16_t k_avg = ((uint16_t)k[0] + k[1] + 1) / 2;
-  if (k_avg < MOTORCAL_K_MIN) k_avg = MOTORCAL_K_MIN;
-  if (k_avg > MOTORCAL_K_MAX) k_avg = MOTORCAL_K_MAX;
-  move_kv = MOTORCAL_KV_LOOP_GAIN / (float)k_avg;
-  for (uint8_t i = 0; i < 2; i++) {
-    move_bd[i] = bd[i];
-    move_inv_k[i] = 1.0f / (float)(k[i] ? k[i] : 1);
-  }
-}
-
 // Checksum over everything in the record except the checksum itself.
 uint16_t calibration_checksum(const CalibrationData &cal) {
   uint16_t sum = cal.magic + cal.calib_min + cal.calib_max + cal.motor.valid;
@@ -896,8 +661,12 @@ uint16_t get_nearest_detent_position(uint8_t detent_count, uint16_t current_posi
   // For 2+ detents: evenly spaced including endpoints
   uint16_t range = input_calib_max - input_calib_min;
 
-  // Calculate offset from minimum position
+  // Below the calibrated minimum is reachable - self-calibration leaves a
+  // buffer inside the physical ends - and the unsigned arithmetic below would
+  // wrap a negative offset into a huge index, clamping to the TOP detent and
+  // yanking the fader the wrong way at full haptic strength.
   int16_t offset = current_position - input_calib_min;
+  if (offset < 0) offset = 0;
 
   // Calculate which detent index is nearest using rounding
   // detent_index = round(offset * (detent_count - 1) / range)
@@ -935,6 +704,15 @@ void request_layer_change(uint8_t new_layer) {
 // times out early or never does.
 void begin_remote_move() {
   uint32_t now = millis();
+  // The take-up ceiling exists for belt slack on a direction reversal, so it is
+  // re-armed when the commanded direction flips - not on every retarget, which
+  // would otherwise pin a host that streams position updates at the take-up duty
+  // forever.
+  int8_t dir = (target_adc > input_ewma) ? 1 : -1;
+  if (get_mode() != MODE_REMOTE_MOVEMENT_IN_PROGRESS || dir != move_direction) {
+    drive_ceiling = move_takeup_duty;
+  }
+  move_direction = dir;
   remote_movement_start = now;
   remote_movement_start_position = input_ewma;
   remote_movement_steady_start = now;
@@ -1041,23 +819,9 @@ void apply_move_speed(uint8_t speed) {
   uint16_t fastest = span * (1000 / MOVE_SPEED_FASTEST_MS);
   uint16_t adc_per_sec =
       slowest + (uint16_t)(((uint32_t)(fastest - slowest) * speed) / (LAYER_SPEED_FULL - 1));
-  // Clamp to what the mechanism can actually sustain smoothly
-  if (adc_per_sec < move_vel_min) adc_per_sec = move_vel_min;
+  // No floor here: the control law re-applies move_vel_min every tick, which is
+  // the authoritative clamp and can't go stale if calibration moves it.
   move_max_velocity = adc_per_sec;
-}
-
-// Direction of travel for the current characterisation run: runs alternate,
-// starting with falling, so each begins where the previous one ended.
-int8_t motorcal_dir() {
-  return (motorcal_run & 1) ? 1 : -1;
-}
-
-// A run drives open-loop, so it has to police its own travel. Bail out before
-// the carriage reaches the mechanical end rather than measuring a fader that
-// is being held by an endstop.
-bool motorcal_out_of_band(int8_t dir) {
-  if (dir > 0) return input_ewma > input_calib_max - MOTORCAL_EDGE_MARGIN;
-  return input_ewma < input_calib_min + MOTORCAL_EDGE_MARGIN;
 }
 
 void motor_update() {
@@ -1101,21 +865,27 @@ void motor_update() {
     }
   }
 
+  // Hysteresis window: `position` only follows input_ewma once it leaves the
+  // window, so ADC noise at rest can't read as user input.
+  int16_t new_position = position;
   if (input_ewma > position_window_upper) {
     position_window_upper = input_ewma;
     position_window_lower = position_window_upper - WINDOW_SIZE;
-    if (mode != MODE_REMOTE_MOVEMENT_IN_PROGRESS && position != position_window_upper) {
-      input_last_change_millis = now;
-    }
-    position = position_window_upper;
+    new_position = position_window_upper;
   } else if (input_ewma < position_window_lower) {
     position_window_lower = input_ewma;
     position_window_upper = position_window_lower + WINDOW_SIZE;
-    if (mode != MODE_REMOTE_MOVEMENT_IN_PROGRESS && position != position_window_lower) {
-      input_last_change_millis = now;
-    }
-    position = position_window_lower;
+    new_position = position_window_lower;
   }
+  if (new_position != position && mode != MODE_REMOTE_MOVEMENT_IN_PROGRESS) {
+    // Movement we didn't command is local input: restart the idle timer, and
+    // flag a position-nonce bump for when it settles, so the host can tell a
+    // user move from the echo of its own command even when the reported 8-bit
+    // position ends up unchanged.
+    input_last_change_millis = now;
+    pending_report_on_idle = true;
+  }
+  position = new_position;
 
 #if DEBUG_DRIVE
   if (debug_drive_active) {
@@ -1143,7 +913,7 @@ void motor_update() {
         float timeout_error = target_adc - input_ewma;
         if (timeout_error < 0) timeout_error = -timeout_error;
         if (timeout_error <= MOVE_TIMEOUT_TOLERANCE) {
-          motor_set(0, false, MOTOR_IDLE_COAST);
+          motor_coast();
           input_last_change_millis = now - IDLE_DURATION_THRESHOLD;
           set_mode(Mode::MODE_INPUT_IDLE);
         } else {
@@ -1163,8 +933,8 @@ void motor_update() {
           // reference, the velocity loop delivers it via feedforward (plant
           // inverted) plus feedback. See "The control law" in
           // ABOUT_MOTOR_CONTROL.md for the derivation.
-          float v_ref = move_vref_slope * error;
-          float mag = v_ref < 0 ? -v_ref : v_ref;
+          float sign = (error > 0) ? 1.0f : -1.0f;
+          float mag = move_vref_slope * error * sign;   // |v_ref|
           if (move_max_velocity > MOVE_VEL_UNLIMITED && mag > move_max_velocity) {
             mag = move_max_velocity;
           }
@@ -1176,9 +946,6 @@ void motor_update() {
 
           uint8_t d = (error > 0) ? MOTORCAL_RISING : MOTORCAL_FALLING;
           float ff = move_bd[d] + mag * move_inv_k[d];
-          if (error < 0) ff = -ff;
-          v_ref = (error > 0) ? mag : -mag;
-          float u = ff + move_kv * (v_ref - velocity_ewma);
 
           // Ramp in extra drive only while stalled. The feedforward is derived
           // to sit above breakaway, so this should now be rare - it covers
@@ -1186,7 +953,7 @@ void motor_update() {
           // case.
           float speed = velocity_ewma < 0 ? -velocity_ewma : velocity_ewma;
           if (speed < MOVE_STALL_VELOCITY) {
-            stiction_ramp += move_ramp_rate * (control_dt_us * 1e-6f);
+            stiction_ramp += move_ramp_rate * dt;
             if (stiction_ramp > MOVE_RAMP_MAX) stiction_ramp = MOVE_RAMP_MAX;
           } else if (stiction_ramp > 0) {
             // Shed it quickly once the carriage breaks free, but not in one
@@ -1194,14 +961,17 @@ void motor_update() {
             // relay, and around the stall threshold it chatters. A few tens of
             // ms is far shorter than the coast time, so it still cannot
             // contribute to overshoot.
-            stiction_ramp -= MOVE_RAMP_DECAY_RATE * (control_dt_us * 1e-6f);
+            stiction_ramp -= MOVE_RAMP_DECAY_RATE * dt;
             if (stiction_ramp < 0) stiction_ramp = 0;
           }
-          u += (error > 0) ? stiction_ramp : -stiction_ramp;
+          // Feedforward plus stall escape, both signed toward the target, and
+          // the velocity loop closing on the signed reference.
+          float u = sign * (ff + stiction_ramp) +
+                    move_kv * (sign * mag - velocity_ewma);
 
           // Drive ceiling opens up over time from the take-up value, easing
           // the motor through belt backlash instead of stepping to full duty.
-          drive_ceiling += move_takeup_ramp_rate * (control_dt_us * 1e-6f);
+          drive_ceiling += move_takeup_ramp_rate * dt;
           if (drive_ceiling > MOVE_MAX_DUTY) drive_ceiling = MOVE_MAX_DUTY;
           int16_t limit = (int16_t)drive_ceiling + (int16_t)stiction_ramp;
           if (limit > MOVE_MAX_DUTY) limit = MOVE_MAX_DUTY;
@@ -1215,15 +985,17 @@ void motor_update() {
           // On target: hold with the bridge braked until we declare the move
           // finished, so a loose carriage can't drift back out of the window.
           stiction_ramp = 0;
-          motor_set(0, true, MOTOR_IDLE_BRAKE);
+          motor_brake();
           if (now > remote_movement_steady_start + REMOTE_MOVEMENT_STEADY_THRESHOLD) {
-            // shift hysteresis window to prevent spurious immediate "input" detection if remote movement left us near the window bounds and succeptiple to noise
+            // Re-centre the hysteresis window on where we stopped. A move
+            // that ends with the carriage near a window bound would otherwise
+            // let ADC noise read as immediate user input.
             if (input_ewma < WINDOW_SIZE / 2) {
               position_window_lower = 0;
               position_window_upper = WINDOW_SIZE;
             } else if (input_ewma > 1023 - WINDOW_SIZE / 2) {
               position_window_upper = 1023;
-              position_window_lower = 1023 - WINDOW_SIZE / 2;
+              position_window_lower = 1023 - WINDOW_SIZE;
             } else {
               position_window_lower = input_ewma - WINDOW_SIZE / 2;
               position_window_upper = position_window_lower + WINDOW_SIZE;
@@ -1242,7 +1014,7 @@ void motor_update() {
       }
 
       if (now > input_last_change_millis + IDLE_DURATION_THRESHOLD && (state & STATE_TOUCH_bm) == 0 && now > touch_state_change_millis + IDLE_DURATION_THRESHOLD) {
-        motor_set(0, false, MOTOR_IDLE_COAST);
+        motor_coast();
         if (pending_report_on_idle) {
           pending_report_on_idle = false;
           increment_position_nonce();
@@ -1266,7 +1038,7 @@ void motor_update() {
             uint8_t pwm = (delta + HAPTIC_BASE_PWM > max_pwm) ? max_pwm : delta + HAPTIC_BASE_PWM;
             motor_set((int16_t)pwm, false, MOTOR_IDLE_COAST);
           } else {
-            motor_set(0, false, MOTOR_IDLE_COAST);
+            motor_coast();
           }
         } else if (haptic_mode == HAPTIC_DETENTS) {
           // Detent haptics - pull toward nearest detent position
@@ -1296,16 +1068,16 @@ void motor_update() {
             }
           } else {
             // Within dead zone, no force
-            motor_set(0, false, MOTOR_IDLE_COAST);
+            motor_coast();
           }
         } else {
           // No haptics for NO_HAPTICS mode
-          motor_set(0, false, MOTOR_IDLE_COAST);
+          motor_coast();
         }
       }
       break;
     case MODE_INPUT_IDLE:
-      motor_set(0, false, MOTOR_IDLE_COAST);
+      motor_coast();
 
       // Apply pending layer change
       if (pending_layer_change != 0xFF) {
@@ -1318,234 +1090,29 @@ void motor_update() {
       }
       break;
     case MODE_ERROR:
-      motor_set(0, false, MOTOR_IDLE_COAST);
+      motor_coast();
       break;
-    case MODE_SELF_CALIBRATION: {
-      // Direction of travel and travel policing are the same for every
-      // measurement stage, so they live here rather than in each case. The
-      // runs drive open loop, so something has to stop them at the ends.
-      int8_t dir = motorcal_dir();
-      // Speed along the direction of travel, as an integer once, so the
-      // measurement stages below never touch the float paths again. One ADC
-      // count/sec is far finer than anything derived from these needs.
-      int16_t speed = (int16_t)((dir > 0) ? velocity_ewma : -velocity_ewma);
-      if (self_calibration_stage >= SELFCAL_MOTOR_RAMP &&
-          self_calibration_stage <= SELFCAL_MOTOR_DWELL_B &&
-          motorcal_out_of_band(dir)) {
-        motorcal_failed = true;
-        self_calibration_stage = SELFCAL_MOTOR_NEXT;
-      }
-      switch (self_calibration_stage) {
-        case SELFCAL_ENDPOINT_LOW:
-          if (now > self_calibration_start + SELF_CALIBRATION_TIMEOUT) {
-            self_calibration_adc_stage_0 = adc_val;
-            self_calibration_stage++;
-            self_calibration_start = millis();
-          } else {
-            // Move toward lower ADC value
-            motor_set(-254, true, MOTOR_IDLE_COAST);
-          }
+    case MODE_SELF_CALIBRATION:
+      switch (motorcal_tick(now, adc_val)) {
+        case MOTORCAL_RUNNING:
           break;
-        case SELFCAL_ENDPOINT_HIGH:
-          if (now > self_calibration_start + SELF_CALIBRATION_TIMEOUT) {
-            self_calibration_adc_stage_1 = adc_val;
-            self_calibration_stage++;
-            self_calibration_start = millis();
-          } else {
-            // Move toward higher ADC value
-            motor_set(254, true, MOTOR_IDLE_COAST);
-          }
+        case MOTORCAL_BAD_SPAN:
+          // No plausible travel between the endpoints - a disconnected motor or
+          // pot, not something a retry fixes.
+          set_mode(Mode::MODE_ERROR);
           break;
-        case SELFCAL_ENDPOINT_APPLY:
-          motor_set(0, false, MOTOR_IDLE_COAST);
-          if (abs((int16_t)self_calibration_adc_stage_0 - self_calibration_adc_stage_1) < 900) {
-            set_mode(Mode::MODE_ERROR);
-          } else {
-            // Apply calibration in memory
-            // Divide by 2 to account for 2-sample ADC aggregation (adc_val is 2x, but input_ewma is corrected)
-            input_calib_min = (SELF_CALIBRATION_BUFFER * self_calibration_adc_stage_0 + (1.0 - SELF_CALIBRATION_BUFFER) * self_calibration_adc_stage_1) / 2;
-            input_calib_max = (SELF_CALIBRATION_BUFFER * self_calibration_adc_stage_1 + (1.0 - SELF_CALIBRATION_BUFFER) * self_calibration_adc_stage_0) / 2;
-
-            // Endpoints are known, so the motor characterisation that follows
-            // has a calibrated span to keep itself inside. Persist once, at the
-            // end, so endpoints and motor data are written together.
-            motorcal_run = 0;
-            motorcal_failed = false;
-            for (uint8_t i = 0; i < 2; i++) {
-              motorcal_bd_sum[i] = 0;
-              motorcal_k_sum[i] = 0;
-              motorcal_vjump_max[i] = 0;
-              motorcal_samples[i] = 0;
-            }
-            self_calibration_stage = SELFCAL_MOTOR_PARK;
-            self_calibration_start = now;
-          }
-          break;
-        case SELFCAL_MOTOR_PARK: {
-          // A run needs room to ramp to breakaway and then dwell twice without
-          // reaching the far end, so it starts from the end it travels away
-          // from. Runs alternate direction, so only the first park is long.
-          bool parked = (dir > 0)
-              ? (input_ewma <= input_calib_min + MOTORCAL_PARK_MARGIN)
-              : (input_ewma >= input_calib_max - MOTORCAL_PARK_MARGIN);
-          if (parked || now > self_calibration_start + MOTORCAL_PARK_TIMEOUT) {
-            motor_set(0, true, MOTOR_IDLE_BRAKE);
-            self_calibration_stage = SELFCAL_MOTOR_SETTLE;
-            self_calibration_start = now;
-          } else {
-            motor_set(dir > 0 ? -MOTORCAL_PARK_DUTY : MOTORCAL_PARK_DUTY,
-                      true, MOTOR_IDLE_COAST);
-          }
-          break;
-        }
-        case SELFCAL_MOTOR_SETTLE:
-          // Breakaway is only meaningful from a standstill: measuring it while
-          // the carriage still coasts would find the (much lower) duty needed
-          // to sustain motion rather than the duty needed to start it.
-          motor_set(0, true, MOTOR_IDLE_BRAKE);
-          if (now > self_calibration_start + MOTORCAL_SETTLE_MS) {
-            motorcal_duty = 0;
-            motorcal_bd = 0;
-            motorcal_vjump = 0;
-            self_calibration_stage = SELFCAL_MOTOR_RAMP;
-            self_calibration_start = now;
-          }
-          break;
-        case SELFCAL_MOTOR_RAMP: {
-          int16_t duty;
-          if (motorcal_bd == 0) {
-            // Still hunting for breakaway. Fixed point, 1/256 duty per LSB:
-            // the ramp is the only thing here needing sub-duty resolution, and
-            // a float multiply per tick for it is not worth the flash. The
-            // fraction has to be fine enough that a tick's increment does not
-            // truncate to nothing - 84/4096 per us is 80.1 duty/sec at the
-            // 500 us tick, where a coarser LSB would quietly give ~62.
-            motorcal_duty += (uint16_t)((control_dt_us * 84UL) >> 12);
-            duty = motorcal_duty >> 8;
-            if (duty > MOTORCAL_RAMP_MAX) {
-              // Nothing moved short of a duty no sane fader needs: jammed, or
-              // the motor isn't connected.
-              motorcal_failed = true;
-              self_calibration_stage = SELFCAL_MOTOR_NEXT;
-              break;
-            }
-            // duty > 0 keeps a still-coasting carriage from "breaking away" at
-            // zero drive, which would also defeat the sentinel below.
-            if (duty > 0 && speed > MOTORCAL_MOTION_VEL) {
-              motorcal_bd = duty;
-              motorcal_vjump = speed;
-              self_calibration_start = now;  // start the jump hold
-            }
-          } else {
-            // Breakaway found (motorcal_bd is the sentinel; it is never 0 for
-            // a real detection). Hold there and take the peak speed. Motion does
-            // not ease in from zero - it jumps (Stribeck) - and that jump is
-            // the floor on the smallest correction the controller can make.
-            duty = motorcal_bd;
-            if (speed > motorcal_vjump) motorcal_vjump = speed;
-            if (now > self_calibration_start + MOTORCAL_JUMP_MS) {
-              motorcal_vel_sum = 0;
-              motorcal_vel_n = 0;
-              self_calibration_stage = SELFCAL_MOTOR_DWELL_A;
-              self_calibration_start = now;
-            }
-          }
-          motor_set((dir > 0) ? duty : -duty, true, MOTOR_IDLE_BRAKE);
-          break;
-        }
-        case SELFCAL_MOTOR_DWELL_A:
-        case SELFCAL_MOTOR_DWELL_B: {
-          // Two fixed duties above breakaway give a two-point fit for k, the
-          // slope of the speed/duty line. One point would only give a speed,
-          // which says nothing about how the plant responds to a change.
-          bool second = (self_calibration_stage == SELFCAL_MOTOR_DWELL_B);
-          int16_t duty = motorcal_bd + (second ? MOTORCAL_DWELL_B : MOTORCAL_DWELL_A);
-          if (duty > MOVE_MAX_DUTY) duty = MOVE_MAX_DUTY;
-          motor_set((dir > 0) ? duty : -duty, true, MOTOR_IDLE_BRAKE);
-
-          // Average the tail of the hold only, once the speed has settled.
-          if (now > self_calibration_start + (MOTORCAL_DWELL_MS - MOTORCAL_DWELL_AVG_MS)) {
-            motorcal_vel_sum += speed;
-            motorcal_vel_n++;
-          }
-          if (now > self_calibration_start + MOTORCAL_DWELL_MS) {
-            int16_t v = (motorcal_vel_n > 0)
-                            ? (int16_t)(motorcal_vel_sum / motorcal_vel_n)
-                            : 0;
-            motorcal_vel_sum = 0;
-            motorcal_vel_n = 0;
-            if (!second) {
-              motorcal_dwell_a = v;
-              self_calibration_stage = SELFCAL_MOTOR_DWELL_B;
-              self_calibration_start = now;
-            } else {
-              int16_t k = (v - motorcal_dwell_a) / (MOTORCAL_DWELL_B - MOTORCAL_DWELL_A);
-              int16_t bd = motorcal_bd;
-              int16_t vjump = motorcal_vjump;
-              uint8_t idx = (dir > 0) ? MOTORCAL_RISING : MOTORCAL_FALLING;
-              if (bd >= MOTORCAL_BD_MIN && bd <= MOTORCAL_BD_MAX &&
-                  k >= MOTORCAL_K_MIN && k <= MOTORCAL_K_MAX &&
-                  vjump >= MOTORCAL_VJUMP_MIN && vjump <= MOTORCAL_VJUMP_MAX) {
-                motorcal_bd_sum[idx] += bd;
-                motorcal_k_sum[idx] += k;
-                if ((uint16_t)vjump > motorcal_vjump_max[idx]) {
-                  motorcal_vjump_max[idx] = vjump;
-                }
-                motorcal_samples[idx]++;
-              } else {
-                motorcal_failed = true;
-              }
-              self_calibration_stage = SELFCAL_MOTOR_NEXT;
-              self_calibration_start = now;
-            }
-          }
-          break;
-        }
-        case SELFCAL_MOTOR_NEXT:
-          motor_set(0, true, MOTOR_IDLE_BRAKE);
-          motorcal_run++;
-          self_calibration_stage =
-              (!motorcal_failed && motorcal_run < 2 * MOTORCAL_PASSES)
-                  ? SELFCAL_MOTOR_PARK
-                  : SELFCAL_FINISH;
-          self_calibration_start = now;
-          break;
-        case SELFCAL_FINISH:
-          motor_set(0, false, MOTOR_IDLE_COAST);
-          // Every run must have produced a plausible sample. A partial set
-          // means something was wrong with the fader or the measurement, and
-          // half-measured gains are worse than the tuned defaults.
-          if (!motorcal_failed && motorcal_samples[MOTORCAL_FALLING] == MOTORCAL_PASSES &&
-              motorcal_samples[MOTORCAL_RISING] == MOTORCAL_PASSES) {
-            motor_cal.valid = 1;
-            for (uint8_t i = 0; i < 2; i++) {
-              motor_cal.bd[i] = (motorcal_bd_sum[i] + MOTORCAL_PASSES / 2) / MOTORCAL_PASSES;
-              motor_cal.k[i] = (motorcal_k_sum[i] + MOTORCAL_PASSES / 2) / MOTORCAL_PASSES;
-              motor_cal.vjump[i] = motorcal_vjump_max[i];
-            }
-          } else {
-            // Endpoints are still good and worth keeping; only the motor
-            // characterisation is discarded, and the tuned defaults stand in.
-            motor_cal.valid = 0;
-            for (uint8_t i = 0; i < 2; i++) {
-              motor_cal.bd[i] = 0;
-              motor_cal.k[i] = 0;
-              motor_cal.vjump[i] = 0;
-            }
-          }
-          apply_motor_calibration();
-
-          // Save calibration to EEPROM
+        case MOTORCAL_DONE:
+          // Endpoints and motor characterisation are persisted together, then
+          // the carriage goes back to where the layer wanted it - re-lerped,
+          // since target_adc came from the bounds we have just replaced.
           saveCalibration();
-
-          // Since we moved the position, do a remote movement to the previous target
-          // TODO: re-calculate target_adc using the new calibration bounds. Can't do that now since we lerp target to an ADC value upon receipt, without saving the 0-255 value
+          target_adc = BOUNDED_LERP_UINT16(layer_restore_positions[active_layer],
+                                           0, 255, input_calib_min, input_calib_max);
           begin_remote_move();
           break;
       }
       break;
-    }
-    }
+  }
 
   // TODO: lerp bounds...
   uint8_t pos = BOUNDED_LERP_UINT16(position, input_calib_min, input_calib_max, 0, 255);
@@ -1738,8 +1305,7 @@ void process_i2c_requests() {
 
   if (self_cal) {
     if (get_mode() != MODE_ERROR) {
-      self_calibration_stage = 0;
-      self_calibration_start = millis();
+      motorcal_begin(millis());
       set_mode(MODE_SELF_CALIBRATION);
     }
   }
@@ -1791,7 +1357,7 @@ void process_i2c_requests() {
     if (debug_drive_flags == DEBUG_DRIVE_FLAGS_EXIT) {
       debug_drive_active = false;
       debug_drive_value = 0;
-      motor_set(0, false, MOTOR_IDLE_COAST);
+      motor_coast();
       // Hand both pins back to the timer, since the closed-loop paths drive
       // HCMPn directly and assume both compare outputs stay enabled.
       TCA0.SPLIT.CTRLB = (TCA_SPLIT_HCMP1EN_bm | TCA_SPLIT_HCMP2EN_bm);
@@ -1823,7 +1389,7 @@ void loop() {
 
   if (pending_calibrate_touch) {
     pending_calibrate_touch = false;
-    motor_set(0, false, MOTOR_IDLE_COAST);
+    motor_coast();
     delay(10);
     ptc_node_request_recal(&touch_sensor);
     // for (uint8_t i = 0; i < 4; i++) {

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -154,6 +154,17 @@ enum TapState : uint8_t {
 #define MOVE_VEL_MIN (560.0f)            // ADC counts/sec
 #define MOVE_VEL_UNLIMITED (0.0f)
 
+// Endpoints of the host-facing unitless speed scale (LAYER_SPEED_SLOWEST ..
+// LAYER_SPEED_FULL - 1), expressed as the time a full-travel move takes. They
+// are the ends of the range the limiter was actually measured over: below
+// MOVE_SPEED_SLOWEST_MS tracking falls apart as the governor runs into the
+// Stribeck floor, and above MOVE_SPEED_FASTEST_MS the limit sits at or beyond
+// what the unlimited controller already does, so it stops having any effect.
+// Mapping the whole byte onto this window means every value a host can send
+// does something, rather than most of the range being unusable.
+#define MOVE_SPEED_SLOWEST_MS (700.0f)
+#define MOVE_SPEED_FASTEST_MS (250.0f)
+
 // On movement timeout, an error this small means the fader is essentially in
 // position and merely hunting - give up quietly rather than latching
 // MODE_ERROR, which needs a host round-trip to clear. Anything larger is a
@@ -268,7 +279,7 @@ uint8_t last_haptic_nonce = 0;  // Track last seen nonce to detect changes [DEPR
 // Layer state storage (27 bytes total) - Protocol v5+
 uint16_t layer_haptic_configs[8];      // 16 bytes - 16-bit haptic config per layer
 uint8_t layer_restore_positions[8];    // 8 bytes - restore position per layer (0-255)
-uint8_t layer_move_times[8];           // 8 bytes - optional full-travel move time per layer (0 = unlimited)
+uint8_t layer_speeds[8];               // 8 bytes - per-layer move speed (see LAYER_SPEED_*)
 uint8_t active_layer = 0;              // 1 byte - currently active layer (0-7)
 uint8_t pending_layer_change = 0xFF;   // 1 byte - deferred layer change (0xFF = none, 0-7 = layer)
 uint8_t queried_layer = 0;             // 1 byte - for layer-addressed read protocol
@@ -296,11 +307,11 @@ volatile uint8_t i2c_layer_change_request = 0xFF;  // 0xFF = none, 0-7 = layer
 struct LayerTargetWrite {
   uint8_t layer;
   uint8_t target;
-  uint8_t move_time; // optional full-travel move time (see LAYER_MOVE_TIME)
-  bool has_move_time;// false = 3-byte legacy write, leave the limit as-is
+  uint8_t speed;     // optional move speed (see LAYER_SPEED_*)
+  bool has_speed;    // false = 3-byte write, leave the layer's speed as-is
   bool valid;
 };
-volatile LayerTargetWrite i2c_layer_target_write = {0, 0, 0, false, false};
+volatile LayerTargetWrite i2c_layer_target_write = {0, 0, LAYER_SPEED_FULL, false, false};
 
 struct LayerHapticWrite {
   uint8_t layer;
@@ -372,7 +383,7 @@ void reset_tap_detection();
 void request_layer_change(uint8_t new_layer);
 void apply_layer_change(uint8_t new_layer);
 void write_layer_target(uint8_t layer, uint8_t target);
-void apply_move_time(uint8_t move_time_10ms);
+void apply_move_speed(uint8_t speed);
 void write_layer_haptic_config(uint8_t layer, uint16_t config);
 
 Mode get_mode() {
@@ -593,13 +604,13 @@ void onI2cReceive(int howMany) {
         // Read setup: register + layer index
         queried_layer = Wire.read() & 0x07;
       } else if (howMany == 3 || howMany == 4) {
-        // Write: register + layer + target position [+ optional speed limit].
+        // Write: register + layer + target position [+ optional speed].
         // The 3-byte form is the original protocol and leaves the layer's
-        // existing speed limit alone, so old controllers are unaffected.
+        // existing speed alone, so old controllers are unaffected.
         i2c_layer_target_write.layer = Wire.read() & 0x07;
         i2c_layer_target_write.target = Wire.read();
-        i2c_layer_target_write.has_move_time = (howMany == 4);
-        i2c_layer_target_write.move_time = (howMany == 4) ? Wire.read() : 0;
+        i2c_layer_target_write.has_speed = (howMany == 4);
+        i2c_layer_target_write.speed = (howMany == 4) ? Wire.read() : LAYER_SPEED_FULL;
         i2c_layer_target_write.valid = true;
       }
       break;
@@ -798,7 +809,7 @@ void apply_layer_change(uint8_t new_layer) {
     layer_restore_positions[new_layer], 0, 255,
     input_calib_min, input_calib_max
   );
-  apply_move_time(layer_move_times[new_layer]);
+  apply_move_speed(layer_speeds[new_layer]);
   remote_movement_start = millis();
   remote_movement_start_position = input_ewma;
   remote_movement_steady_start = millis();
@@ -821,7 +832,7 @@ void write_layer_target(uint8_t layer, uint8_t target) {
       // Start remote movement
       layer_restore_positions[layer] = target;
       target_adc = BOUNDED_LERP_UINT16(target, 0, 255, input_calib_min, input_calib_max);
-      apply_move_time(layer_move_times[layer]);
+      apply_move_speed(layer_speeds[layer]);
       set_mode(MODE_REMOTE_MOVEMENT_IN_PROGRESS);
       remote_movement_start = millis();
       remote_movement_start_position = input_ewma;
@@ -832,7 +843,7 @@ void write_layer_target(uint8_t layer, uint8_t target) {
       // Update target of in-progress movement
       layer_restore_positions[layer] = target;
       target_adc = BOUNDED_LERP_UINT16(target, 0, 255, input_calib_min, input_calib_max);
-      apply_move_time(layer_move_times[layer]);
+      apply_move_speed(layer_speeds[layer]);
       remote_movement_start = millis();
       remote_movement_start_position = input_ewma;
       remote_movement_steady_start = millis();
@@ -879,19 +890,24 @@ void adc_drain() {
   }
 }
 
-// Translate a layer's move-time byte into the velocity limit used by the
-// control law. The byte is the time a full-scale (0-255) move should take, in
-// units of 10 ms; 0 means unlimited. Since the whole calibrated span is crossed
-// in that time, the velocity is simply span/time.
-void apply_move_time(uint8_t move_time_10ms) {
-  if (move_time_10ms == LAYER_MOVE_TIME_UNLIMITED) {
+// Translate a layer's unitless speed byte into the velocity limit used by the
+// control law. LAYER_SPEED_FULL means no limit; below that the byte maps
+// linearly in VELOCITY (not in move time) across the validated window, so the
+// host-facing scale is a speed dial and equal steps feel like equal changes.
+// The window is expressed as full-travel times, so the endpoints are stated in
+// the same terms the measurements were taken in; the calibrated span converts
+// each to a velocity.
+void apply_move_speed(uint8_t speed) {
+  if (speed >= LAYER_SPEED_FULL) {
     move_max_velocity = MOVE_VEL_UNLIMITED;
     move_max_error = 1023.0f;
     return;
   }
   uint16_t span = input_calib_max - input_calib_min;
-  float ms = (float)move_time_10ms * LAYER_MOVE_TIME_MS_PER_UNIT;
-  float adc_per_sec = (float)span * 1000.0f / ms;
+  float slowest = (float)span * 1000.0f / MOVE_SPEED_SLOWEST_MS;
+  float fastest = (float)span * 1000.0f / MOVE_SPEED_FASTEST_MS;
+  float adc_per_sec =
+      slowest + (fastest - slowest) * ((float)speed / (float)(LAYER_SPEED_FULL - 1));
   // Clamp to what the mechanism can actually sustain smoothly
   if (adc_per_sec < MOVE_VEL_MIN) adc_per_sec = MOVE_VEL_MIN;
   move_max_velocity = adc_per_sec;
@@ -1270,7 +1286,7 @@ void setup() {
   for (uint8_t i = 0; i < 8; i++) {
     layer_haptic_configs[i] = 0;  // Default: HAPTIC_NO_HAPTICS (smooth mode), all bits 0
     layer_restore_positions[i] = 128;  // Default: midpoint
-    layer_move_times[i] = LAYER_MOVE_TIME_UNLIMITED;
+    layer_speeds[i] = LAYER_SPEED_FULL;
   }
   active_layer = 0;
   pending_layer_change = 0xFF;  // No pending change
@@ -1325,8 +1341,8 @@ void process_i2c_requests() {
   bool has_layer_target = false;
   uint8_t layer_target_layer = 0;
   uint8_t layer_target_target = 0;
-  uint8_t layer_target_move_time = 0;
-  bool layer_target_has_move_time = false;
+  uint8_t layer_target_speed = LAYER_SPEED_FULL;
+  bool layer_target_has_speed = false;
   bool has_layer_haptic = false;
   uint8_t layer_haptic_layer = 0;
   uint16_t layer_haptic_config = 0;
@@ -1355,8 +1371,8 @@ void process_i2c_requests() {
     has_layer_target = true;
     layer_target_layer = i2c_layer_target_write.layer;
     layer_target_target = i2c_layer_target_write.target;
-    layer_target_move_time = i2c_layer_target_write.move_time;
-    layer_target_has_move_time = i2c_layer_target_write.has_move_time;
+    layer_target_speed = i2c_layer_target_write.speed;
+    layer_target_has_speed = i2c_layer_target_write.has_speed;
     i2c_layer_target_write.valid = false;
   }
 
@@ -1400,8 +1416,8 @@ void process_i2c_requests() {
   }
 
   if (has_layer_target) {
-    if (layer_target_has_move_time) {
-      layer_move_times[layer_target_layer & 0x07] = layer_target_move_time;
+    if (layer_target_has_speed) {
+      layer_speeds[layer_target_layer & 0x07] = layer_target_speed;
     }
     write_layer_target(layer_target_layer, layer_target_target);
   }

--- a/firmware/src/motor_cal.cpp
+++ b/firmware/src/motor_cal.cpp
@@ -1,0 +1,427 @@
+/*
+ * Copyright 2026 Scott Bezek
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <Arduino.h>
+
+#include "motor_cal.h"
+#include "motor_control.h"
+
+MotorCalData motor_cal = {0, {0, 0}, {0, 0}, {0, 0}};
+
+// Three things are measured about this motor, per direction, and the MOVE_*
+// gains in motor_control.h are re-derived from them (apply_motor_calibration):
+//
+//   breakaway  the duty at which the carriage first moves at all
+//   k          ADC counts/sec of cruise gained per duty count above breakaway
+//   v_jump     the speed motion starts at the instant breakaway is crossed
+//
+// See "Per-unit motor characterisation" in ABOUT_MOTOR_CONTROL.md for why a
+// fixed set of gains can't serve every unit and how these are derived.
+
+// Target open-loop gain for the velocity loop, k*KV, held constant across
+// units by scaling KV with 1/k. 1.16 is what the reference unit ran at.
+#define MOTORCAL_KV_LOOP_GAIN (1.16f)
+
+// Bounds on the derived velocity floor (1.25x the Stribeck jump).
+#define MOTORCAL_VEL_MIN_LO (200)
+#define MOTORCAL_VEL_MIN_HI (1500)
+
+// Time from the carriage reaching the deadband to actually stopping -
+// reaction + detection + coast, not coast alone (see ABOUT_MOTOR_CONTROL.md).
+#define MOTORCAL_STOP_TIME_MS (15)       // ms
+#define MOTORCAL_TAKEUP_MARGIN (20)      // take-up ceiling sits this far above FF
+// Bounds on the derived on-target window.
+#define MOTORCAL_DEADBAND_LO (8)         // ADC counts
+#define MOTORCAL_DEADBAND_HI (20)
+
+// Measurement procedure: park, ramp to breakaway, then dwell at two duties
+// above breakaway for a two-point fit of k. Runs alternate direction, so each
+// one starts where the previous one left off.
+#define MOTORCAL_PASSES (2)              // runs per direction, averaged
+#define MOTORCAL_RAMP_RATE (80)          // duty/sec
+// The ramp accumulates in fixed point at 1/256 duty per LSB, stepped per
+// microsecond of tick as MOTORCAL_RAMP_STEP/4096. The 1/4096 is fine enough
+// that a 500 us tick's increment doesn't truncate away most of itself.
+#define MOTORCAL_RAMP_STEP \
+  (((uint32_t)MOTORCAL_RAMP_RATE * 256 * 4096 + 500000UL) / 1000000UL)
+#define MOTORCAL_RAMP_MAX (200)         // give up: this unit has no usable breakaway
+#define MOTORCAL_MOTION_VEL (200)       // ADC counts/sec that counts as "moving"
+#define MOTORCAL_JUMP_MS (40)            // window for capturing the Stribeck jump
+#define MOTORCAL_DWELL_A (25)            // duty above breakaway, first fit point
+#define MOTORCAL_DWELL_B (50)            // duty above breakaway, second fit point
+#define MOTORCAL_DWELL_MS (100)          // hold per fit point
+#define MOTORCAL_DWELL_AVG_MS (50)       // average over the last part of the hold
+#define MOTORCAL_SETTLE_MS (200)         // coast to a stop before ramping
+#define MOTORCAL_PARK_MARGIN (60)        // ADC counts from the end to start a run
+#define MOTORCAL_PARK_DUTY (200)         // open-loop duty used to park
+#define MOTORCAL_PARK_TIMEOUT (2500)     // ms
+#define MOTORCAL_EDGE_MARGIN (25)        // abort if a run gets this close to an end
+
+// Plausibility bounds - outside these, the measurement (not the fader) is
+// wrong, so fall back to the compiled defaults.
+#define MOTORCAL_BD_MIN (10)
+#define MOTORCAL_BD_MAX (180)
+#define MOTORCAL_K_MIN (8)
+#define MOTORCAL_K_MAX (90)
+#define MOTORCAL_VJUMP_MIN (100)
+#define MOTORCAL_VJUMP_MAX (4000)
+
+static uint32_t self_calibration_start = 0;
+static uint8_t self_calibration_stage = 0;
+#define SELF_CALIBRATION_TIMEOUT (1500)
+#define SELF_CALIBRATION_BUFFER (0.995)  // Buffer factor to prevent hitting physical limits
+static uint16_t self_calibration_adc_stage_0 = 0;
+static uint16_t self_calibration_adc_stage_1 = 0;
+
+// Self-calibration runs the endpoint sweep first, then characterises the motor
+// (see the MOTORCAL_* constants). Stages 0-2 are the original endpoint sweep;
+// their numbering is unchanged.
+enum SelfCalStage : uint8_t {
+  SELFCAL_ENDPOINT_LOW = 0,   // drive to the low end, record it
+  SELFCAL_ENDPOINT_HIGH,      // drive to the high end, record it
+  SELFCAL_ENDPOINT_APPLY,     // validate the span, adopt it in RAM
+  SELFCAL_MOTOR_PARK,         // drive to the end this run starts from
+  SELFCAL_MOTOR_SETTLE,       // coast to a genuine stop before measuring
+  SELFCAL_MOTOR_RAMP,         // ramp to breakaway, then hold and capture the jump
+  SELFCAL_MOTOR_DWELL_A,      // hold breakaway + A, measure cruise speed
+  SELFCAL_MOTOR_DWELL_B,      // hold breakaway + B, measure cruise speed
+  SELFCAL_MOTOR_NEXT,         // fold in the run, advance or finish
+  SELFCAL_FINISH,             // derive gains, persist, return to the target
+};
+
+// Motor characterisation working state. Runs alternate direction starting with
+// falling (the endpoint sweep leaves the carriage at the high end), so each run
+// begins where the previous one ended.
+static uint8_t motorcal_run = 0;          // 0..2*MOTORCAL_PASSES-1; even falling, odd rising
+static bool motorcal_failed = false;
+static uint16_t motorcal_duty = 0;        // ramped duty, fixed point (1/256 duty per LSB)
+static int16_t motorcal_bd = 0;           // breakaway duty found by this run
+static int16_t motorcal_vjump = 0;        // peak speed just after breakaway, ADC/s
+static int16_t motorcal_dwell_a = 0;      // cruise speed at breakaway + A, ADC/s
+static int32_t motorcal_vel_sum = 0;      // dwell velocity accumulator
+static uint16_t motorcal_vel_n = 0;
+// Per-direction accumulators, indexed [0] = falling, [1] = rising. Integer,
+// because flash is the scarce resource on this part and a duty count or an
+// ADC count/sec is all the resolution any of these needs.
+static uint16_t motorcal_bd_sum[2] = {0, 0};
+static uint16_t motorcal_k_sum[2] = {0, 0};
+static uint16_t motorcal_vjump_max[2] = {0, 0};
+static uint8_t motorcal_samples[2] = {0, 0};
+
+// Re-derive the live control gains from this unit's measured motor
+// characteristics, or restore the compiled-in defaults when no valid
+// measurement exists. Safe to call at any time; it only touches gains. See
+// "What is derived" in ABOUT_MOTOR_CONTROL.md for the formulas.
+void apply_motor_calibration() {
+  // The compiled-in defaults are themselves a plant model - the reference
+  // unit's - so there is one derivation, not one per case: an uncharacterised
+  // fader runs exactly the gains the constants were tuned to.
+  uint8_t bd[2], k[2];
+  uint16_t vjump;
+  if (motor_cal.valid) {
+    bd[MOTORCAL_FALLING] = motor_cal.bd[MOTORCAL_FALLING];
+    bd[MOTORCAL_RISING] = motor_cal.bd[MOTORCAL_RISING];
+    k[MOTORCAL_FALLING] = motor_cal.k[MOTORCAL_FALLING];
+    k[MOTORCAL_RISING] = motor_cal.k[MOTORCAL_RISING];
+    vjump = (motor_cal.vjump[0] > motor_cal.vjump[1]) ? motor_cal.vjump[0]
+                                                      : motor_cal.vjump[1];
+  } else {
+    bd[MOTORCAL_FALLING] = MOVE_BD_FALLING;
+    bd[MOTORCAL_RISING] = MOVE_BD_RISING;
+    k[MOTORCAL_FALLING] = MOVE_K_DEFAULT;
+    k[MOTORCAL_RISING] = MOVE_K_DEFAULT;
+    vjump = MOVE_VJUMP_DEFAULT;
+  }
+
+  // The Stribeck jump is the slowest the mechanism moves at all, so it floors
+  // both the velocity reference and the on-target window: the fader cannot
+  // correct by less than the distance it covers before it can be stopped.
+  uint16_t vel_min = vjump + vjump / 4;  // 1.25x, for margin above the floor
+  if (vel_min < MOTORCAL_VEL_MIN_LO) vel_min = MOTORCAL_VEL_MIN_LO;
+  if (vel_min > MOTORCAL_VEL_MIN_HI) vel_min = MOTORCAL_VEL_MIN_HI;
+  move_vel_min = vel_min;
+
+  uint16_t deadband = (uint16_t)(((uint32_t)vel_min * MOTORCAL_STOP_TIME_MS + 500) / 1000);
+  if (deadband < MOTORCAL_DEADBAND_LO) deadband = MOTORCAL_DEADBAND_LO;
+  if (deadband > MOTORCAL_DEADBAND_HI) deadband = MOTORCAL_DEADBAND_HI;
+  move_deadband = deadband;
+
+  // Take-up ceiling: limits drive at the start of a move so the belt is not
+  // engaged at full duty. It has to stay above the feedforward at the floor
+  // speed, or it starves the term that gets the carriage moving. Integer
+  // arithmetic deliberately - this runs once, but flash is permanent.
+  int16_t takeup = MOVE_TAKEUP_DUTY;
+  for (uint8_t i = 0; i < 2; i++) {
+    int16_t ff = bd[i] + (int16_t)(vel_min / (k[i] ? k[i] : 1)) + MOTORCAL_TAKEUP_MARGIN;
+    if (ff > takeup) takeup = ff;
+  }
+  if (takeup > MOVE_MAX_DUTY) takeup = MOVE_MAX_DUTY;
+  move_takeup_duty = takeup;
+
+  // The only float work: the control law needs 1/k per direction for the
+  // feedforward, and the velocity loop gain scaled so its open-loop gain k*KV
+  // - the thing that actually sets damping - matches the reference unit's.
+  uint16_t k_avg = ((uint16_t)k[0] + k[1] + 1) / 2;
+  if (k_avg < MOTORCAL_K_MIN) k_avg = MOTORCAL_K_MIN;
+  if (k_avg > MOTORCAL_K_MAX) k_avg = MOTORCAL_K_MAX;
+  move_kv = MOTORCAL_KV_LOOP_GAIN / (float)k_avg;
+  for (uint8_t i = 0; i < 2; i++) {
+    move_bd[i] = bd[i];
+    move_inv_k[i] = 1.0f / (float)(k[i] ? k[i] : 1);
+  }
+}
+
+// Direction of travel for the current characterisation run: runs alternate,
+// starting with falling, so each begins where the previous one ended.
+static int8_t motorcal_dir() {
+  return (motorcal_run & 1) ? 1 : -1;
+}
+
+// A run drives open-loop, so it has to police its own travel. Bail out before
+// the carriage reaches the mechanical end rather than measuring a fader that
+// is being held by an endstop.
+static bool motorcal_out_of_band(int8_t dir) {
+  if (dir > 0) return input_ewma > input_calib_max - MOTORCAL_EDGE_MARGIN;
+  return input_ewma < input_calib_min + MOTORCAL_EDGE_MARGIN;
+}
+
+// Start a self-calibration run at the endpoint sweep.
+void motorcal_begin(uint32_t now) {
+  self_calibration_stage = SELFCAL_ENDPOINT_LOW;
+  self_calibration_start = now;
+}
+
+MotorCalResult motorcal_tick(uint32_t now, uint16_t adc_raw) {
+  // Direction of travel and travel policing are the same for every
+  // measurement stage, so they live here rather than in each case. The
+  // runs drive open loop, so something has to stop them at the ends.
+  int8_t dir = motorcal_dir();
+  // Speed along the direction of travel, as an integer once, so the
+  // measurement stages below never touch the float paths again. One ADC
+  // count/sec is far finer than anything derived from these needs.
+  int16_t speed = (int16_t)((dir > 0) ? velocity_ewma : -velocity_ewma);
+  if (self_calibration_stage >= SELFCAL_MOTOR_RAMP &&
+      self_calibration_stage <= SELFCAL_MOTOR_DWELL_B &&
+      motorcal_out_of_band(dir)) {
+    motorcal_failed = true;
+    self_calibration_stage = SELFCAL_MOTOR_NEXT;
+  }
+  switch (self_calibration_stage) {
+    case SELFCAL_ENDPOINT_LOW:
+      if (now > self_calibration_start + SELF_CALIBRATION_TIMEOUT) {
+        self_calibration_adc_stage_0 = adc_raw;
+        self_calibration_stage++;
+        self_calibration_start = millis();
+      } else {
+        // Move toward lower ADC value
+        motor_set(-254, true, MOTOR_IDLE_COAST);
+      }
+      break;
+    case SELFCAL_ENDPOINT_HIGH:
+      if (now > self_calibration_start + SELF_CALIBRATION_TIMEOUT) {
+        self_calibration_adc_stage_1 = adc_raw;
+        self_calibration_stage++;
+        self_calibration_start = millis();
+      } else {
+        // Move toward higher ADC value
+        motor_set(254, true, MOTOR_IDLE_COAST);
+      }
+      break;
+    case SELFCAL_ENDPOINT_APPLY:
+      motor_coast();
+      if (abs((int16_t)self_calibration_adc_stage_0 - self_calibration_adc_stage_1) < 900) {
+        return MOTORCAL_BAD_SPAN;
+      } else {
+        // Adopt the measured span, pulled in by the buffer factor so the
+        // ends stay clear of the mechanical stops. Halved because the
+        // stage readings are raw (2x accumulation) and the bounds are
+        // compared against input_ewma, which is in ADC counts.
+        input_calib_min = (SELF_CALIBRATION_BUFFER * self_calibration_adc_stage_0 + (1.0 - SELF_CALIBRATION_BUFFER) * self_calibration_adc_stage_1) / 2;
+        input_calib_max = (SELF_CALIBRATION_BUFFER * self_calibration_adc_stage_1 + (1.0 - SELF_CALIBRATION_BUFFER) * self_calibration_adc_stage_0) / 2;
+
+        // Endpoints are known, so the motor characterisation that follows
+        // has a calibrated span to keep itself inside. Persist once, at the
+        // end, so endpoints and motor data are written together.
+        motorcal_run = 0;
+        motorcal_failed = false;
+        for (uint8_t i = 0; i < 2; i++) {
+          motorcal_bd_sum[i] = 0;
+          motorcal_k_sum[i] = 0;
+          motorcal_vjump_max[i] = 0;
+          motorcal_samples[i] = 0;
+        }
+        self_calibration_stage = SELFCAL_MOTOR_PARK;
+        self_calibration_start = now;
+      }
+      break;
+    case SELFCAL_MOTOR_PARK: {
+      // A run needs room to ramp to breakaway and then dwell twice without
+      // reaching the far end, so it starts from the end it travels away
+      // from. Runs alternate direction, so only the first park is long.
+      bool parked = (dir > 0)
+          ? (input_ewma <= input_calib_min + MOTORCAL_PARK_MARGIN)
+          : (input_ewma >= input_calib_max - MOTORCAL_PARK_MARGIN);
+      if (parked || now > self_calibration_start + MOTORCAL_PARK_TIMEOUT) {
+        motor_brake();
+        self_calibration_stage = SELFCAL_MOTOR_SETTLE;
+        self_calibration_start = now;
+      } else {
+        motor_set(dir > 0 ? -MOTORCAL_PARK_DUTY : MOTORCAL_PARK_DUTY,
+                  true, MOTOR_IDLE_COAST);
+      }
+      break;
+    }
+    case SELFCAL_MOTOR_SETTLE:
+      // Breakaway is only meaningful from a standstill: measuring it while
+      // the carriage still coasts would find the (much lower) duty needed
+      // to sustain motion rather than the duty needed to start it.
+      motor_brake();
+      if (now > self_calibration_start + MOTORCAL_SETTLE_MS) {
+        motorcal_duty = 0;
+        motorcal_bd = 0;
+        motorcal_vjump = 0;
+        self_calibration_stage = SELFCAL_MOTOR_RAMP;
+        self_calibration_start = now;
+      }
+      break;
+    case SELFCAL_MOTOR_RAMP: {
+      int16_t duty;
+      if (motorcal_bd == 0) {
+        // Still hunting for breakaway. Fixed point (see MOTORCAL_RAMP_STEP):
+        // the ramp is the only thing here needing sub-duty resolution, and a
+        // float multiply per tick for it is not worth the flash. Truncation
+        // per tick costs a little rate - 78 duty/sec realised at the 500 us
+        // tick against the nominal 80 - which the breakaway search absorbs.
+        motorcal_duty += (uint16_t)((control_dt_us * MOTORCAL_RAMP_STEP) >> 12);
+        duty = motorcal_duty >> 8;
+        if (duty > MOTORCAL_RAMP_MAX) {
+          // Nothing moved short of a duty no sane fader needs: jammed, or
+          // the motor isn't connected.
+          motorcal_failed = true;
+          self_calibration_stage = SELFCAL_MOTOR_NEXT;
+          break;
+        }
+        // duty > 0 keeps a still-coasting carriage from "breaking away" at
+        // zero drive, which would also defeat the sentinel below.
+        if (duty > 0 && speed > MOTORCAL_MOTION_VEL) {
+          motorcal_bd = duty;
+          motorcal_vjump = speed;
+          self_calibration_start = now;  // start the jump hold
+        }
+      } else {
+        // Breakaway found (motorcal_bd is the sentinel; it is never 0 for
+        // a real detection). Hold there and take the peak speed. Motion does
+        // not ease in from zero - it jumps (Stribeck) - and that jump is
+        // the floor on the smallest correction the controller can make.
+        duty = motorcal_bd;
+        if (speed > motorcal_vjump) motorcal_vjump = speed;
+        if (now > self_calibration_start + MOTORCAL_JUMP_MS) {
+          motorcal_vel_sum = 0;
+          motorcal_vel_n = 0;
+          self_calibration_stage = SELFCAL_MOTOR_DWELL_A;
+          self_calibration_start = now;
+        }
+      }
+      motor_set((dir > 0) ? duty : -duty, true, MOTOR_IDLE_BRAKE);
+      break;
+    }
+    case SELFCAL_MOTOR_DWELL_A:
+    case SELFCAL_MOTOR_DWELL_B: {
+      // Two fixed duties above breakaway give a two-point fit for k, the
+      // slope of the speed/duty line. One point would only give a speed,
+      // which says nothing about how the plant responds to a change.
+      bool second = (self_calibration_stage == SELFCAL_MOTOR_DWELL_B);
+      int16_t duty = motorcal_bd + (second ? MOTORCAL_DWELL_B : MOTORCAL_DWELL_A);
+      if (duty > MOVE_MAX_DUTY) duty = MOVE_MAX_DUTY;
+      motor_set((dir > 0) ? duty : -duty, true, MOTOR_IDLE_BRAKE);
+
+      // Average the tail of the hold only, once the speed has settled.
+      if (now > self_calibration_start + (MOTORCAL_DWELL_MS - MOTORCAL_DWELL_AVG_MS)) {
+        motorcal_vel_sum += speed;
+        motorcal_vel_n++;
+      }
+      if (now > self_calibration_start + MOTORCAL_DWELL_MS) {
+        int16_t v = (motorcal_vel_n > 0)
+                        ? (int16_t)(motorcal_vel_sum / motorcal_vel_n)
+                        : 0;
+        motorcal_vel_sum = 0;
+        motorcal_vel_n = 0;
+        if (!second) {
+          motorcal_dwell_a = v;
+          self_calibration_stage = SELFCAL_MOTOR_DWELL_B;
+          self_calibration_start = now;
+        } else {
+          int16_t k = (v - motorcal_dwell_a) / (MOTORCAL_DWELL_B - MOTORCAL_DWELL_A);
+          int16_t bd = motorcal_bd;
+          int16_t vjump = motorcal_vjump;
+          uint8_t idx = (dir > 0) ? MOTORCAL_RISING : MOTORCAL_FALLING;
+          if (bd >= MOTORCAL_BD_MIN && bd <= MOTORCAL_BD_MAX &&
+              k >= MOTORCAL_K_MIN && k <= MOTORCAL_K_MAX &&
+              vjump >= MOTORCAL_VJUMP_MIN && vjump <= MOTORCAL_VJUMP_MAX) {
+            motorcal_bd_sum[idx] += bd;
+            motorcal_k_sum[idx] += k;
+            if ((uint16_t)vjump > motorcal_vjump_max[idx]) {
+              motorcal_vjump_max[idx] = vjump;
+            }
+            motorcal_samples[idx]++;
+          } else {
+            motorcal_failed = true;
+          }
+          self_calibration_stage = SELFCAL_MOTOR_NEXT;
+          self_calibration_start = now;
+        }
+      }
+      break;
+    }
+    case SELFCAL_MOTOR_NEXT:
+      motor_brake();
+      motorcal_run++;
+      self_calibration_stage =
+          (!motorcal_failed && motorcal_run < 2 * MOTORCAL_PASSES)
+              ? SELFCAL_MOTOR_PARK
+              : SELFCAL_FINISH;
+      self_calibration_start = now;
+      break;
+    case SELFCAL_FINISH:
+      motor_coast();
+      // Every run must have produced a plausible sample. A partial set
+      // means something was wrong with the fader or the measurement, and
+      // half-measured gains are worse than the tuned defaults.
+      if (!motorcal_failed && motorcal_samples[MOTORCAL_FALLING] == MOTORCAL_PASSES &&
+          motorcal_samples[MOTORCAL_RISING] == MOTORCAL_PASSES) {
+        motor_cal.valid = 1;
+        for (uint8_t i = 0; i < 2; i++) {
+          motor_cal.bd[i] = (motorcal_bd_sum[i] + MOTORCAL_PASSES / 2) / MOTORCAL_PASSES;
+          motor_cal.k[i] = (motorcal_k_sum[i] + MOTORCAL_PASSES / 2) / MOTORCAL_PASSES;
+          motor_cal.vjump[i] = motorcal_vjump_max[i];
+        }
+      } else {
+        // Endpoints are still good and worth keeping; only the motor
+        // characterisation is discarded, and the tuned defaults stand in.
+        motor_cal.valid = 0;
+        for (uint8_t i = 0; i < 2; i++) {
+          motor_cal.bd[i] = 0;
+          motor_cal.k[i] = 0;
+          motor_cal.vjump[i] = 0;
+        }
+      }
+      apply_motor_calibration();
+
+      // The caller persists the record and returns the carriage to its
+      // target; both need state this module has no business reaching into.
+      return MOTORCAL_DONE;
+  }
+  return MOTORCAL_RUNNING;
+}

--- a/firmware/src/motor_cal.h
+++ b/firmware/src/motor_cal.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 Scott Bezek
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Per-unit motor characterisation: measures this fader's plant during
+// self-calibration and re-derives the control law's gains from it. See
+// "Per-unit motor characterisation" in ABOUT_MOTOR_CONTROL.md for why a single
+// fixed set of gains can't serve every unit, and how these are derived.
+
+#pragma once
+
+#include <stdint.h>
+
+// What was measured, as reported at REG_MOTOR_CAL. Held separately from the
+// derived gains so the raw measurement stays inspectable, and persisted in the
+// same EEPROM record as the endpoints. Indexed [MOTORCAL_FALLING]/[MOTORCAL_RISING].
+struct MotorCalData {
+  uint8_t valid;      // 0 = never measured, or measured implausibly
+  uint8_t bd[2];      // breakaway duty
+  uint8_t k[2];       // ADC counts/sec per duty above breakaway
+  uint16_t vjump[2];  // ADC counts/sec at the moment motion starts
+};
+
+extern MotorCalData motor_cal;
+
+// Re-derive the live control gains from motor_cal, or restore the compiled-in
+// defaults when it holds no valid measurement. Safe to call at any time; it
+// only touches gains.
+void apply_motor_calibration();
+
+enum MotorCalResult : uint8_t {
+  MOTORCAL_RUNNING = 0,  // still sweeping or measuring
+  MOTORCAL_DONE,         // motor_cal and the endpoints are settled; persist them
+  MOTORCAL_BAD_SPAN,     // the endpoint sweep found no plausible travel
+};
+
+// Start a self-calibration run: endpoint sweep first, then the motor
+// characterisation. The caller owns the mode; this owns the motor until it
+// returns something other than MOTORCAL_RUNNING.
+void motorcal_begin(uint32_t now);
+
+// Advance one control tick. `adc_raw` is the latest raw (2x accumulated)
+// conversion, used for the endpoint sweep.
+MotorCalResult motorcal_tick(uint32_t now, uint16_t adc_raw);

--- a/firmware/src/motor_control.h
+++ b/firmware/src/motor_control.h
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2026 Scott Bezek
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Motor drive primitives and the remote-movement control law's tuning, shared
+// between the control loop in main.cpp (which owns every definition here) and
+// the per-unit characterisation in motor_cal.cpp (which derives the live gains
+// from a measurement of the plant).
+
+#pragma once
+
+#include <stdint.h>
+
+// PA4 = Motor A (WO4/HCMP1), PA5 = Motor B (WO5/HCMP2). Both feed the DRV8837
+// IN1/IN2 inputs: 1/0 = forward, 0/1 = reverse, 0/0 = coast (Hi-Z), 1/1 = brake.
+enum MotorIdle : uint8_t {
+  MOTOR_IDLE_COAST = 0,  // Bridge Hi-Z: fader is free to move
+  MOTOR_IDLE_BRAKE = 1,  // Both low sides on: dynamic braking against motion
+};
+
+void motor_set(int16_t drive, bool slow_decay, MotorIdle idle_mode);
+void motor_coast();
+void motor_brake();
+
+// Direction of travel, used to index every per-direction quantity here and in
+// the characterisation. "Rising" is toward the motor end, where ADC increases.
+#define MOTORCAL_FALLING (0)
+#define MOTORCAL_RISING (1)
+
+// ---------------------------------------------------------------------------
+// Remote-movement control law, in ADC counts. Grouped by stage of the cascade,
+// matching "The control law" in ABOUT_MOTOR_CONTROL.md - read the two together
+// for the derivation and for how these were centred for hardware variance.
+// ---------------------------------------------------------------------------
+
+// Position loop: error -> velocity reference.
+#define MOVE_VREF_SLOPE (50.0f)         // ADC counts/sec of reference per ADC count of error
+// The mechanism stick-slips below the Stribeck floor rather than moving, so the
+// reference is never allowed under it. Holding it there next to the target is
+// also what keeps the feedforward clear of breakaway for small errors.
+#define MOVE_VEL_MIN (560)              // ADC counts/sec
+#define MOVE_VEL_UNLIMITED (0.0f)       // move_max_velocity: no speed limit requested
+
+// Friction feedforward: u_ff = breakaway + v_ref/k, the plant inverted. These
+// are the reference unit's measured plant; a characterised unit overrides them.
+#define MOVE_BD_RISING (68)             // assumed breakaway duty, rising ADC
+#define MOVE_BD_FALLING (86)            // assumed breakaway duty, falling ADC
+#define MOVE_K_DEFAULT (29)             // assumed ADC counts/sec per duty count
+#define MOVE_VJUMP_DEFAULT (448)        // assumed Stribeck jump; 1.25x it is MOVE_VEL_MIN
+
+// Velocity loop: closes on the reference. What sets damping is the open-loop
+// gain k*KV, so this is scaled by 1/k when the unit has been characterised.
+#define MOVE_KV (0.04f)                 // duty per (ADC count/sec) of velocity error
+
+// Stall escape: extra drive ramped in only while commanded to move but not
+// moving, so a unit whose breakaway sits above the feedforward still completes
+// a move instead of sitting stuck outside the deadband until the timeout.
+#define MOVE_STALL_VELOCITY (60.0f)     // ADC counts/sec below which we're stalled
+#define MOVE_RAMP_RATE (250.0f)         // duty per second of ramp-in
+#define MOVE_RAMP_MAX (70.0f)           // ceiling, so a jam can't wind up to full drive
+#define MOVE_RAMP_DECAY_RATE (3500.0f)  // duty/sec shed once moving (~20 ms from full)
+
+// Backlash take-up: a direction-reversed move starts with the motor unloaded,
+// so full duty would spin the rotor through the belt slack and snap it taut -
+// an audible click and a jerk. The drive ceiling instead starts low and opens
+// up over time. Time-based, not "are we moving yet": crossing the slack the
+// rotor is already moving, just unloaded. Must stay above the feedforward or it
+// starves the term that gets the carriage moving.
+#define MOVE_TAKEUP_DUTY (130)           // duty ceiling when a move is armed
+#define MOVE_TAKEUP_RAMP_RATE (1200.0f)  // duty per second the ceiling opens up
+
+// Move termination. The deadband has a hard floor set by the plant, not by
+// taste - see ABOUT_MOTOR_CONTROL.md. Don't lower it below that floor.
+#define MOVE_DEADBAND (8.0f)            // ADC counts considered "on target"
+#define MOVE_MAX_DUTY (254)
+// On movement timeout, an error below this means the fader arrived but is
+// still dithering - go idle instead of latching MODE_ERROR.
+#define MOVE_TIMEOUT_TOLERANCE (20.0f)  // ADC counts
+
+// Endpoints of the host-facing unitless speed scale (LAYER_SPEED_SLOWEST ..
+// LAYER_SPEED_FULL - 1), as the full-travel time at each end - the validated
+// range of the speed limiter. See "Optional speed limiting" in
+// ABOUT_MOTOR_CONTROL.md.
+#define MOVE_SPEED_SLOWEST_MS (700)
+#define MOVE_SPEED_FASTEST_MS (250)
+
+// Live gains. The MOVE_* constants above are the defaults for a unit that has
+// never been characterised; apply_motor_calibration() (motor_cal.cpp) derives
+// these from a real measurement when one exists, and DEBUG_DRIVE builds let a
+// host overwrite them at runtime via REG_DEBUG_GAINS.
+extern float move_bd[2];         // breakaway duty, per direction
+extern float move_inv_k[2];      // duty per (ADC count/sec), per direction
+extern float move_kv;            // velocity loop gain
+extern int16_t move_takeup_duty;
+extern float move_deadband;
+extern float move_vel_min;
+
+// Measured interval of the current control tick, in microseconds. Measured from
+// the previous execution rather than the scheduled tick time, so a late tick
+// doesn't skew anything derived from it.
+extern uint32_t control_dt_us;
+
+// Plant state the characterisation measures against.
+extern float input_ewma;         // filtered position, ADC counts
+extern float velocity_ewma;      // ADC counts/sec, + toward the motor end
+extern uint16_t input_calib_min;
+extern uint16_t input_calib_max;

--- a/firmware/src/shared/i2c_data.h
+++ b/firmware/src/shared/i2c_data.h
@@ -58,6 +58,12 @@
  * -----|---------------------|---------|------|------------
  * 0x0F | LAYER_HAPTIC_CONFIG | R/W     | -    | Layer haptic config (layer-addressed, u16)
  * -----|---------------------|---------|------|------------
+ * 0x10 | DEBUG_DRIVE         | W       | u8[2]| Open-loop motor drive (DEBUG_DRIVE builds only)
+ * -----|---------------------|---------|------|------------
+ * 0x11 | DEBUG_STATUS        | R       |u8[16]| Control-loop internals (DEBUG_DRIVE builds only)
+ * -----|---------------------|---------|------|------------
+ * 0x12 | DEBUG_GAINS         | W       | u8[3]| Runtime gain override (DEBUG_DRIVE builds only)
+ * -----|---------------------|---------|------|------------
  *
  * Protocol:
  * - Simple registers:
@@ -91,6 +97,60 @@
 #define REG_ACTIVE_LAYER 0x0D  // Active layer index (R/W, u8)
 #define REG_LAYER_TARGET 0x0E  // Layer restore position (layer-addressed, R/W, u8)
 #define REG_LAYER_HAPTIC_CONFIG 0x0F  // Layer haptic config (layer-addressed, R/W, u16)
+#define REG_DEBUG_DRIVE 0x10  // Open-loop motor drive (W, [flags, duty]); DEBUG_DRIVE builds only
+
+/*
+ * REG_DEBUG_DRIVE (0x10) - write-only, present only in DEBUG_DRIVE builds.
+ *
+ * Write [0x10, flags, duty] to command the H-bridge directly, bypassing the
+ * control loop, for system identification. Writing flags = 0xFF exits open-loop
+ * mode. The firmware coasts the motor if a command is not refreshed within
+ * 400 ms, or if the fader nears a travel limit.
+ */
+#define DEBUG_DRIVE_FLAGS_EXIT (0xFF)
+
+// Direction: 2 bits at position 0
+#define DEBUG_DRIVE_DIR_bp (0)
+#define DEBUG_DRIVE_DIR_bm (0x03 << DEBUG_DRIVE_DIR_bp)
+#define DEBUG_DRIVE_DIR_COAST (0)
+#define DEBUG_DRIVE_DIR_A     (1)  // Toward the motor end (rising ADC)
+#define DEBUG_DRIVE_DIR_B     (2)  // Toward the low end (falling ADC)
+#define DEBUG_DRIVE_DIR_BRAKE (3)  // Both low sides on (dynamic braking)
+
+// Decay mode: 1 bit at position 2 (0 = fast/coast, 1 = slow/brake)
+#define DEBUG_DRIVE_SLOW_DECAY_bp (2)
+#define DEBUG_DRIVE_SLOW_DECAY_bm (1 << DEBUG_DRIVE_SLOW_DECAY_bp)
+
+// PWM prescaler select: 2 bits at position 4
+// 0 = DIV4 (19.6 kHz), 1 = DIV256 (306 Hz), 2 = DIV2 (39.2 kHz), 3 = DIV8 (9.8 kHz)
+#define DEBUG_DRIVE_CLK_bp (4)
+#define DEBUG_DRIVE_CLK_bm (0x03 << DEBUG_DRIVE_CLK_bp)
+
+/*
+ * REG_DEBUG_STATUS (0x11) - read-only, DEBUG_DRIVE builds only.
+ * 16 bytes, big-endian: calib_min u16, calib_max u16, target_adc i16,
+ * drive i16, velocity i16 (ADC counts/sec), error_x8 i16 (error * 8),
+ * loop_hz u16, tick_hz u16.
+ */
+#define REG_DEBUG_STATUS 0x11
+
+/*
+ * REG_DEBUG_GAINS (0x12) - write-only, DEBUG_DRIVE builds only.
+ * Write [0x12, index, value_hi, value_lo] to override one control-loop gain at
+ * runtime, so tuning doesn't need a reflash per trial. Values are fixed point:
+ * KP and KD are scaled by 1000, the rest are integers.
+ */
+#define REG_DEBUG_GAINS 0x12
+#define DEBUG_GAIN_KP          (0)  // duty per ADC count, x1000
+#define DEBUG_GAIN_KD          (1)  // duty per (ADC count/sec), x1000
+#define DEBUG_GAIN_FF_RISING   (2)  // duty
+#define DEBUG_GAIN_FF_FALLING  (3)  // duty
+#define DEBUG_GAIN_DEADBAND    (4)  // ADC counts, x1000
+#define DEBUG_GAIN_TICK_US     (5)  // control tick period, microseconds
+#define DEBUG_GAIN_RAMP_RATE   (6)  // stiction ramp rate, duty per second
+#define DEBUG_GAIN_TAKEUP      (7)  // backlash take-up duty ceiling (0 = disabled)
+#define DEBUG_GAIN_CALIB_MIN   (8)  // override calib_min (RAM only, not saved)
+#define DEBUG_GAIN_CALIB_MAX   (9)  // override calib_max (RAM only, not saved)
 
 enum Mode : uint8_t {
   MODE_REMOTE_MOVEMENT_IN_PROGRESS = 0,

--- a/firmware/src/shared/i2c_data.h
+++ b/firmware/src/shared/i2c_data.h
@@ -54,7 +54,7 @@
  * -----|---------------------|---------|------|------------
  * 0x0D | ACTIVE_LAYER        | R/W     | u8   | Active layer index (0-7)
  * -----|---------------------|---------|------|------------
- * 0x0E | LAYER_TARGET        | R/W     | -    | Layer restore position (layer-addressed, see below)
+ * 0x0E | LAYER_TARGET        | R/W     | -    | Layer restore position + optional move time (see below)
  * -----|---------------------|---------|------|------------
  * 0x0F | LAYER_HAPTIC_CONFIG | R/W     | -    | Layer haptic config (layer-addressed, u16)
  * -----|---------------------|---------|------|------------
@@ -72,6 +72,12 @@
  * - Layer-addressed registers (0x0E, 0x0F):
  *   - Read:  Write [register, layer], then read N bytes for that layer
  *   - Write: Write [register, layer, ...data] to write to specific layer
+ *
+ * LAYER_TARGET (0x0E) accepts an OPTIONAL trailing speed-limit byte:
+ *   [0x0E, layer, position]           - move at full speed (unchanged behaviour)
+ *   [0x0E, layer, position, move_time] - move no faster than this
+ * Three-byte writes behave exactly as before, so this is backwards compatible
+ * and does not change the protocol version. See LAYER_MOVE_TIME below.
  * - All multi-byte values are big-endian (MSB first)
  *
  * v5 Breaking Changes from v4:
@@ -97,6 +103,29 @@
 #define REG_ACTIVE_LAYER 0x0D  // Active layer index (R/W, u8)
 #define REG_LAYER_TARGET 0x0E  // Layer restore position (layer-addressed, R/W, u8)
 #define REG_LAYER_HAPTIC_CONFIG 0x0F  // Layer haptic config (layer-addressed, R/W, u16)
+/*
+ * Optional move-time limit for LAYER_TARGET writes.
+ *
+ * The byte is the time a FULL-SCALE move (0 -> 255) should take, in units of
+ * 10 ms. 0 means unlimited (the default, and what a 3-byte write leaves in
+ * place). So 100 = "one second for full travel"; range 10 ms .. 2550 ms.
+ *
+ * It is a velocity cap, not a move scheduler: a shorter move takes
+ * proportionally less time rather than being stretched to fill the duration.
+ *
+ * This is a LIMIT and not a precise speed. It is realised through a
+ * friction-dependent plant, so actual timing varies with the fader - expect
+ * within roughly 15% for full-travel times up to ~800 ms, and about 7%
+ * difference between the two directions of travel.
+ *
+ * The mechanism cannot move smoothly below roughly 200 position counts/sec, so
+ * requests slower than about 1.2 s of full travel are clamped rather than
+ * honoured; below that speed the motor creeps in stick-slip steps instead of
+ * moving continuously.
+ */
+#define LAYER_MOVE_TIME_UNLIMITED (0)
+#define LAYER_MOVE_TIME_MS_PER_UNIT (10)
+
 #define REG_DEBUG_DRIVE 0x10  // Open-loop motor drive (W, [flags, duty]); DEBUG_DRIVE builds only
 
 /*
@@ -149,6 +178,7 @@
 #define DEBUG_GAIN_TICK_US     (5)  // control tick period, microseconds
 #define DEBUG_GAIN_RAMP_RATE   (6)  // stiction ramp rate, duty per second
 #define DEBUG_GAIN_TAKEUP      (7)  // backlash take-up duty ceiling (0 = disabled)
+#define DEBUG_GAIN_TAKEUP_RAMP (10) // take-up ceiling ramp rate, duty per second
 #define DEBUG_GAIN_CALIB_MIN   (8)  // override calib_min (RAM only, not saved)
 #define DEBUG_GAIN_CALIB_MAX   (9)  // override calib_max (RAM only, not saved)
 

--- a/firmware/src/shared/i2c_data.h
+++ b/firmware/src/shared/i2c_data.h
@@ -54,15 +54,17 @@
  * -----|---------------------|---------|------|------------
  * 0x0D | ACTIVE_LAYER        | R/W     | u8   | Active layer index (0-7)
  * -----|---------------------|---------|------|------------
- * 0x0E | LAYER_TARGET        | R/W     | -    | Layer restore position + optional move time (see below)
+ * 0x0E | LAYER_TARGET        | R/W     | -    | Layer restore position + optional speed (see below)
  * -----|---------------------|---------|------|------------
  * 0x0F | LAYER_HAPTIC_CONFIG | R/W     | -    | Layer haptic config (layer-addressed, u16)
  * -----|---------------------|---------|------|------------
- * 0x10 | DEBUG_DRIVE         | W       | u8[2]| Open-loop motor drive (DEBUG_DRIVE builds only)
+ * 0x10 | ...                 |         |      | (free - next production register goes here)
  * -----|---------------------|---------|------|------------
- * 0x11 | DEBUG_STATUS        | R       |u8[16]| Control-loop internals (DEBUG_DRIVE builds only)
+ * 0xF0 | DEBUG_DRIVE         | W       | u8[2]| Open-loop motor drive (DEBUG_DRIVE builds only)
  * -----|---------------------|---------|------|------------
- * 0x12 | DEBUG_GAINS         | W       | u8[3]| Runtime gain override (DEBUG_DRIVE builds only)
+ * 0xF1 | DEBUG_STATUS        | R       |u8[16]| Control-loop internals (DEBUG_DRIVE builds only)
+ * -----|---------------------|---------|------|------------
+ * 0xF2 | DEBUG_GAINS         | W       | u8[3]| Runtime gain override (DEBUG_DRIVE builds only)
  * -----|---------------------|---------|------|------------
  *
  * Protocol:
@@ -73,11 +75,11 @@
  *   - Read:  Write [register, layer], then read N bytes for that layer
  *   - Write: Write [register, layer, ...data] to write to specific layer
  *
- * LAYER_TARGET (0x0E) accepts an OPTIONAL trailing speed-limit byte:
- *   [0x0E, layer, position]           - move at full speed (unchanged behaviour)
- *   [0x0E, layer, position, move_time] - move no faster than this
+ * LAYER_TARGET (0x0E) accepts an OPTIONAL trailing speed byte:
+ *   [0x0E, layer, position]        - move at full speed (unchanged behaviour)
+ *   [0x0E, layer, position, speed] - move no faster than this
  * Three-byte writes behave exactly as before, so this is backwards compatible
- * and does not change the protocol version. See LAYER_MOVE_TIME below.
+ * and does not change the protocol version. See LAYER_SPEED below.
  * - All multi-byte values are big-endian (MSB first)
  *
  * v5 Breaking Changes from v4:
@@ -104,34 +106,44 @@
 #define REG_LAYER_TARGET 0x0E  // Layer restore position (layer-addressed, R/W, u8)
 #define REG_LAYER_HAPTIC_CONFIG 0x0F  // Layer haptic config (layer-addressed, R/W, u16)
 /*
- * Optional move-time limit for LAYER_TARGET writes.
+ * Optional speed byte for LAYER_TARGET writes.
  *
- * The byte is the time a FULL-SCALE move (0 -> 255) should take, in units of
- * 10 ms. 0 means unlimited (the default, and what a 3-byte write leaves in
- * place). So 100 = "one second for full travel"; range 10 ms .. 2550 ms.
+ * A unitless 0-255 speed: 255 is full speed (no limit, the default), and 0 is
+ * the slowest the mechanism moves smoothly. The scale is linear in velocity
+ * and its ends are the ends of the validated range - roughly 700 ms of full
+ * travel at 0, down to 250 ms at 254 - so every value is usable and there are
+ * no awkward bounds for a host to know about.
  *
  * It is a velocity cap, not a move scheduler: a shorter move takes
- * proportionally less time rather than being stretched to fill the duration.
+ * proportionally less time rather than being stretched to fill a duration.
  *
  * This is a LIMIT and not a precise speed. It is realised through a
  * friction-dependent plant, so actual timing varies with the fader - expect
- * within roughly 15% for full-travel times up to ~800 ms, and about 7%
- * difference between the two directions of travel.
+ * within roughly 15% of the nominal speed, and about 7% difference between the
+ * two directions of travel. Speeds below the bottom of the scale are not
+ * reachable at all: the motor cannot sustain continuous rotation there and
+ * creeps in stick-slip steps instead, which is why 0 stops where it does.
  *
- * The mechanism cannot move smoothly below roughly 200 position counts/sec, so
- * requests slower than about 1.2 s of full travel are clamped rather than
- * honoured; below that speed the motor creeps in stick-slip steps instead of
- * moving continuously.
+ * A 3-byte write leaves the layer's stored speed alone, and layers power up at
+ * LAYER_SPEED_FULL, so a host that never sends the byte moves at full speed.
+ * Send full-speed moves as 3-byte writes: firmware predating this byte ignores
+ * a 4-byte write entirely rather than moving.
  */
-#define LAYER_MOVE_TIME_UNLIMITED (0)
-#define LAYER_MOVE_TIME_MS_PER_UNIT (10)
-
-#define REG_DEBUG_DRIVE 0x10  // Open-loop motor drive (W, [flags, duty]); DEBUG_DRIVE builds only
+#define LAYER_SPEED_SLOWEST (0)
+#define LAYER_SPEED_FULL (255)
 
 /*
- * REG_DEBUG_DRIVE (0x10) - write-only, present only in DEBUG_DRIVE builds.
+ * Debug registers live at the top of the address space, not immediately after
+ * the production registers, so that adding a real register never has to step
+ * over them or leave a hole where they used to be. They are compiled out of
+ * production builds entirely, so nothing on a shipped board answers here.
+ */
+#define REG_DEBUG_DRIVE 0xF0  // Open-loop motor drive (W, [flags, duty]); DEBUG_DRIVE builds only
+
+/*
+ * REG_DEBUG_DRIVE (0xF0) - write-only, present only in DEBUG_DRIVE builds.
  *
- * Write [0x10, flags, duty] to command the H-bridge directly, bypassing the
+ * Write [0xF0, flags, duty] to command the H-bridge directly, bypassing the
  * control loop, for system identification. Writing flags = 0xFF exits open-loop
  * mode. The firmware coasts the motor if a command is not refreshed within
  * 400 ms, or if the fader nears a travel limit.
@@ -156,20 +168,20 @@
 #define DEBUG_DRIVE_CLK_bm (0x03 << DEBUG_DRIVE_CLK_bp)
 
 /*
- * REG_DEBUG_STATUS (0x11) - read-only, DEBUG_DRIVE builds only.
+ * REG_DEBUG_STATUS (0xF1) - read-only, DEBUG_DRIVE builds only.
  * 16 bytes, big-endian: calib_min u16, calib_max u16, target_adc i16,
  * drive i16, velocity i16 (ADC counts/sec), error_x8 i16 (error * 8),
  * loop_hz u16, tick_hz u16.
  */
-#define REG_DEBUG_STATUS 0x11
+#define REG_DEBUG_STATUS 0xF1
 
 /*
- * REG_DEBUG_GAINS (0x12) - write-only, DEBUG_DRIVE builds only.
- * Write [0x12, index, value_hi, value_lo] to override one control-loop gain at
+ * REG_DEBUG_GAINS (0xF2) - write-only, DEBUG_DRIVE builds only.
+ * Write [0xF2, index, value_hi, value_lo] to override one control-loop gain at
  * runtime, so tuning doesn't need a reflash per trial. Values are fixed point:
  * KP and KD are scaled by 1000, the rest are integers.
  */
-#define REG_DEBUG_GAINS 0x12
+#define REG_DEBUG_GAINS 0xF2
 #define DEBUG_GAIN_KP          (0)  // duty per ADC count, x1000
 #define DEBUG_GAIN_KD          (1)  // duty per (ADC count/sec), x1000
 #define DEBUG_GAIN_FF_RISING   (2)  // duty

--- a/firmware/src/shared/i2c_data.h
+++ b/firmware/src/shared/i2c_data.h
@@ -208,8 +208,11 @@
  *
  * A 3-byte write leaves the layer's stored speed alone, and layers power up at
  * LAYER_SPEED_FULL, so a host that never sends the byte moves at full speed.
- * Send full-speed moves as 3-byte writes: firmware predating this byte ignores
- * a 4-byte write entirely rather than moving.
+ *
+ * A host that DOES use the byte should send it on every move, LAYER_SPEED_FULL
+ * included: dropping back to a 3-byte write re-applies whatever limit the layer
+ * last stored, rather than moving at full speed. Send 3 bytes only when talking
+ * to firmware that predates the byte, which ignores a 4-byte write entirely.
  */
 #define LAYER_SPEED_SLOWEST (0)
 #define LAYER_SPEED_FULL (255)

--- a/firmware/src/shared/i2c_data.h
+++ b/firmware/src/shared/i2c_data.h
@@ -18,6 +18,40 @@
 #include <stdint.h>
 
 #define I2C_PROTOCOL_VERSION (5)  // v5: Layer management in firmware, 16-bit haptic config
+// The protocol version covers the WIRE FORMAT of the registers below, and is
+// deliberately not bumped for additive changes that older hosts can ignore -
+// the LAYER_TARGET speed byte being the case in point. Feature-detect on
+// FW_VERSION instead; hosts that hard-fail on an unexpected protocol version
+// would otherwise be bricked by a bump they didn't need to care about.
+
+/*
+ * Application firmware version, as a packed u16: (major << 8) | minor.
+ * Reported at REG_FW_VERSION, and MONOTONICALLY INCREASING, so a host can both
+ * feature-gate on it and compare it against a packaged image to decide whether
+ * an update is needed. Bump the minor on every released build that changes
+ * observable behaviour.
+ *
+ * Two values are reserved and never reported by a real build:
+ *   0x0000 - unused
+ *   0xFFFF - what an I2C read returns from firmware that has no FW_VERSION
+ *            register at all: the peripheral stops driving SDA for an unknown
+ *            register and the bus pulls high. Firmware that old is treated as
+ *            version 1.0 - the last unversioned release.
+ *
+ * Overridable via build flag (-DFW_VERSION=N) so one-off builds can stamp a
+ * different version without touching this default.
+ */
+#define FW_VERSION_MAJOR (1)
+#define FW_VERSION_MINOR (1)
+#ifndef FW_VERSION
+#define FW_VERSION ((FW_VERSION_MAJOR << 8) | FW_VERSION_MINOR)
+#endif
+#define FW_VERSION_NONE (0xFFFF)  // read back from firmware predating the register
+
+// Minimum firmware version that honours the LAYER_TARGET speed byte. Older
+// firmware ignores a 4-byte write completely, so a host MUST check this before
+// sending one rather than letting the move be silently dropped.
+#define FW_VERSION_MOVE_SPEED (0x0101)  // 1.1
 
 
 /*
@@ -58,7 +92,11 @@
  * -----|---------------------|---------|------|------------
  * 0x0F | LAYER_HAPTIC_CONFIG | R/W     | -    | Layer haptic config (layer-addressed, u16)
  * -----|---------------------|---------|------|------------
- * 0x10 | ...                 |         |      | (free - next production register goes here)
+ * 0x10 | (reserved)          |         |      | Reserved for ENTER_BOOTLOADER (I2C bootloader work)
+ * -----|---------------------|---------|------|------------
+ * 0x11 | FW_VERSION          | R       | u16  | Application firmware version (see FW_VERSION)
+ * -----|---------------------|---------|------|------------
+ * 0x12 | ...                 |         |      | (free - next production register goes here)
  * -----|---------------------|---------|------|------------
  * 0xF0 | DEBUG_DRIVE         | W       | u8[2]| Open-loop motor drive (DEBUG_DRIVE builds only)
  * -----|---------------------|---------|------|------------
@@ -105,6 +143,8 @@
 #define REG_ACTIVE_LAYER 0x0D  // Active layer index (R/W, u8)
 #define REG_LAYER_TARGET 0x0E  // Layer restore position (layer-addressed, R/W, u8)
 #define REG_LAYER_HAPTIC_CONFIG 0x0F  // Layer haptic config (layer-addressed, R/W, u16)
+// 0x10 reserved for REG_ENTER_BOOTLOADER (see the I2C bootloader work)
+#define REG_FW_VERSION 0x11  // Application firmware version (R, u16 big-endian, see FW_VERSION)
 /*
  * Optional speed byte for LAYER_TARGET writes.
  *

--- a/firmware/src/shared/i2c_data.h
+++ b/firmware/src/shared/i2c_data.h
@@ -42,7 +42,7 @@
  * different version without touching this default.
  */
 #define FW_VERSION_MAJOR (1)
-#define FW_VERSION_MINOR (1)
+#define FW_VERSION_MINOR (2)
 #ifndef FW_VERSION
 #define FW_VERSION ((FW_VERSION_MAJOR << 8) | FW_VERSION_MINOR)
 #endif
@@ -52,6 +52,10 @@
 // firmware ignores a 4-byte write completely, so a host MUST check this before
 // sending one rather than letting the move be silently dropped.
 #define FW_VERSION_MOVE_SPEED (0x0101)  // 1.1
+
+// Minimum firmware version that measures motor characteristics during
+// self-calibration and reports them at REG_MOTOR_CAL.
+#define FW_VERSION_MOTOR_CAL (0x0102)  // 1.2
 
 
 /*
@@ -96,7 +100,9 @@
  * -----|---------------------|---------|------|------------
  * 0x11 | FW_VERSION          | R       | u16  | Application firmware version (see FW_VERSION)
  * -----|---------------------|---------|------|------------
- * 0x12 | ...                 |         |      | (free - next production register goes here)
+ * 0x12 | MOTOR_CAL           | R       |u8[12]| Measured motor characteristics (see below)
+ * -----|---------------------|---------|------|------------
+ * 0x13 | ...                 |         |      | (free - next production register goes here)
  * -----|---------------------|---------|------|------------
  * 0xF0 | DEBUG_DRIVE         | W       | u8[2]| Open-loop motor drive (DEBUG_DRIVE builds only)
  * -----|---------------------|---------|------|------------
@@ -145,6 +151,42 @@
 #define REG_LAYER_HAPTIC_CONFIG 0x0F  // Layer haptic config (layer-addressed, R/W, u16)
 // 0x10 reserved for REG_ENTER_BOOTLOADER (see the I2C bootloader work)
 #define REG_FW_VERSION 0x11  // Application firmware version (R, u16 big-endian, see FW_VERSION)
+#define REG_MOTOR_CAL 0x12  // Measured motor characteristics (R, 12 bytes, see below)
+
+/*
+ * REG_MOTOR_CAL (0x12) - read-only, 12 bytes.
+ *
+ * What self-calibration measured about THIS motor, and the feedforward it
+ * derived from it. Purely diagnostic: the firmware needs no host involvement
+ * to use these, and a host that ignores the register loses nothing.
+ *
+ * The control law is written against three per-unit plant parameters, because
+ * the same duty means different things on different faders (see
+ * firmware/ABOUT_MOTOR_CONTROL.md):
+ *
+ *   breakaway  duty at which the carriage first moves at all
+ *   k          ADC counts/sec of cruise per duty count above breakaway
+ *   v_jump     the speed motion starts at once breakaway is crossed - the
+ *              Stribeck jump, which sets the floor on the on-target deadband
+ *
+ *   byte  0    valid          1 = measured, 0 = using compiled-in defaults
+ *   byte  1    breakaway_rising   duty
+ *   byte  2    breakaway_falling  duty
+ *   byte  3    k_rising           ADC counts/sec per duty
+ *   byte  4    k_falling          ADC counts/sec per duty
+ *   bytes 5-6  v_jump_rising      ADC counts/sec, big-endian u16
+ *   bytes 7-8  v_jump_falling     ADC counts/sec, big-endian u16
+ *   bytes 9-10 vel_min            slowest velocity reference the control law
+ *                                 will ask for, ADC counts/sec, big-endian u16
+ *   byte 11    deadband           on-target window, ADC counts
+ *
+ * breakaway and k feed the feedforward (breakaway + v_ref/k) and the velocity
+ * loop gain (scaled by 1/k); v_jump sets vel_min and the deadband floor.
+ *
+ * With valid = 0 the measurement never ran, or ran and produced values outside
+ * the plausible range; bytes 1-8 are then zero and 9-11 report the compiled-in
+ * defaults actually in use. Trigger a measurement with REG_SELF_CAL.
+ */
 /*
  * Optional speed byte for LAYER_TARGET writes.
  *
@@ -222,10 +264,12 @@
  * KP and KD are scaled by 1000, the rest are integers.
  */
 #define REG_DEBUG_GAINS 0xF2
-#define DEBUG_GAIN_KP          (0)  // duty per ADC count, x1000
-#define DEBUG_GAIN_KD          (1)  // duty per (ADC count/sec), x1000
-#define DEBUG_GAIN_FF_RISING   (2)  // duty
-#define DEBUG_GAIN_FF_FALLING  (3)  // duty
+#define DEBUG_GAIN_VREF_SLOPE  (0)  // velocity reference per ADC count of error, x1000
+#define DEBUG_GAIN_KV          (1)  // duty per (ADC count/sec) of velocity error, x1000
+#define DEBUG_GAIN_BD_RISING   (2)  // assumed breakaway duty, rising
+#define DEBUG_GAIN_BD_FALLING  (3)  // assumed breakaway duty, falling
+#define DEBUG_GAIN_K           (11) // assumed ADC counts/sec per duty, both directions
+#define DEBUG_GAIN_VEL_MIN     (12) // velocity reference floor, ADC counts/sec
 #define DEBUG_GAIN_DEADBAND    (4)  // ADC counts, x1000
 #define DEBUG_GAIN_TICK_US     (5)  // control tick period, microseconds
 #define DEBUG_GAIN_RAMP_RATE   (6)  // stiction ramp rate, duty per second

--- a/platformio.ini
+++ b/platformio.ini
@@ -41,3 +41,12 @@ build_flags =
  -DCONFIG_ADDR_2_PIN=PIN_PC0
 
  -DCONFIG_CUSTOM_HOOKS=1
+
+; System-identification build: adds the open-loop REG_DEBUG_DRIVE register used
+; by production_tools/programAndTest (env:lab) to characterise the motor.
+; Not for production - it lets a host drive the H-bridge directly.
+[env:fader_buddy_lab]
+extends = env:fader_buddy
+build_flags =
+ ${env:fader_buddy.build_flags}
+ -DDEBUG_DRIVE=1

--- a/production_tools/programAndTest/.vscode/extensions.json
+++ b/production_tools/programAndTest/.vscode/extensions.json
@@ -5,6 +5,7 @@
         "platformio.platformio-ide"
     ],
     "unwantedRecommendations": [
-        "ms-vscode.cpptools-extension-pack"
+        "ms-vscode.cpptools-extension-pack",
+        "pioarduino.pioarduino-ide"
     ]
 }

--- a/production_tools/programAndTest/platformio.ini
+++ b/production_tools/programAndTest/platformio.ini
@@ -35,3 +35,19 @@ board_build.filesystem = littlefs
 board_build.partitions = default.csv
 monitor_speed = 115200
 upload_port = /dev/serial/by-id/usb-Silicon_Labs_CP2104_USB_to_UART_Bridge_Controller_02280A9E-if00-port0
+build_src_filter = +<*> -<lab_main.cpp>
+
+; Control-loop tuning harness - see src/lab_main.cpp. Replaces the production
+; test state machine with a serial command interface for step-response capture.
+[env:lab]
+platform = espressif32@6.12
+board = esp32dev
+framework = arduino
+lib_deps =
+    madhephaestus/ESP32Servo @ 3.0.9
+    adafruit/Adafruit INA3221 Library @ 1.0.1
+build_flags =
+    -I../../firmware/src/shared
+build_src_filter = +<lab_main.cpp> +<fader_buddy_i2c.cpp>
+monitor_speed = 921600
+upload_port = /dev/serial/by-id/usb-Silicon_Labs_CP2104_USB_to_UART_Bridge_Controller_02280A9E-if00-port0

--- a/production_tools/programAndTest/src/lab_main.cpp
+++ b/production_tools/programAndTest/src/lab_main.cpp
@@ -1,0 +1,535 @@
+/*
+ * Copyright 2026 Scott Bezek
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Control-loop tuning harness ("lab" env) for the programAndTest jig.
+ *
+ * Replaces the production test state machine with a line-oriented serial
+ * command interface so a host script can command motion and capture
+ * high-rate position traces for step-response analysis.
+ *
+ * Build/flash:  pio run -e lab --target upload
+ */
+
+#include <Arduino.h>
+#include <Wire.h>
+#include <ESP32Servo.h>
+
+#include "Adafruit_INA3221.h"
+#include "fader_buddy_i2c.h"
+
+#define PIN_LED_RED 21
+#define PIN_LED_GREEN 22
+
+#define PIN_INA_SCL 13
+#define PIN_INA_SDA 17
+
+#define PIN_FADER_BUDDY_SCL 27
+#define PIN_FADER_BUDDY_SDA 26
+
+#define PIN_SERVO 32
+#define SERVO_TOUCH_POS 88
+#define SERVO_CLEAR_POS 50
+
+// INA3221 channels: 0 = 3.3V logic rail, 1 = 5V motor rail
+#define INA_CH_LOGIC 0
+#define INA_CH_MOTOR 1
+
+Adafruit_INA3221 ina3221;
+TwoWire WireFaderBuddy = TwoWire(1);
+FaderBuddyI2C faderBuddy;
+Servo servo;
+
+bool inaPresent = false;
+
+// ---------------------------------------------------------------------------
+// Trace buffer
+// ---------------------------------------------------------------------------
+#define MAX_SAMPLES 6000
+
+struct Sample {
+  uint32_t t_us;
+  uint32_t state;
+};
+
+Sample samples[MAX_SAMPLES];
+uint16_t sampleCount = 0;
+uint16_t stopSampleIndex = 0;  // index at which drive was cut (stopdist)
+
+// Motor rail current is sampled on a slower cadence (separate I2C bus, slow ADC)
+#define MAX_CURRENT_SAMPLES 400
+struct CurrentSample {
+  uint32_t t_us;
+  float mA;
+};
+CurrentSample currentSamples[MAX_CURRENT_SAMPLES];
+uint16_t currentSampleCount = 0;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+static inline uint8_t stateMode(uint32_t s) {
+  return (s & STATE_MODE_bm) >> STATE_MODE_bp;
+}
+static inline uint8_t statePosition(uint32_t s) {
+  return (s & STATE_POSITION_bm) >> STATE_POSITION_bp;
+}
+static inline uint16_t stateRawAdc(uint32_t s) {
+  return (s & STATE_RAW_ADC_bm) >> STATE_RAW_ADC_bp;
+}
+
+// Capture position samples for `durationMs`, sampling motor current every
+// `currentPeriodMs` (0 disables current sampling).
+void capture(uint32_t durationMs, uint32_t currentPeriodMs) {
+  sampleCount = 0;
+  currentSampleCount = 0;
+  uint32_t startUs = micros();
+  uint32_t endUs = startUs + durationMs * 1000UL;
+  uint32_t nextCurrentUs = startUs;
+
+  while ((int32_t)(micros() - endUs) < 0 && sampleCount < MAX_SAMPLES) {
+    uint32_t s;
+    uint32_t t = micros();
+    if (faderBuddy.readState(s)) {
+      samples[sampleCount].t_us = t - startUs;
+      samples[sampleCount].state = s;
+      sampleCount++;
+    }
+    if (currentPeriodMs > 0 && inaPresent &&
+        (int32_t)(micros() - nextCurrentUs) >= 0 &&
+        currentSampleCount < MAX_CURRENT_SAMPLES) {
+      uint32_t tc = micros();
+      currentSamples[currentSampleCount].t_us = tc - startUs;
+      currentSamples[currentSampleCount].mA =
+          ina3221.getCurrentAmps(INA_CH_MOTOR) * 1000.0f;
+      currentSampleCount++;
+      nextCurrentUs += currentPeriodMs * 1000UL;
+    }
+  }
+}
+
+void dumpTrace() {
+  Serial.println("#BEGIN");
+  Serial.print("#samples=");
+  Serial.println(sampleCount);
+  Serial.print("#stop_index=");
+  Serial.println(stopSampleIndex);
+  Serial.println("#cols=t_us,raw_adc,pos,mode,touch");
+  for (uint16_t i = 0; i < sampleCount; i++) {
+    uint32_t s = samples[i].state;
+    Serial.print(samples[i].t_us);
+    Serial.print(',');
+    Serial.print(stateRawAdc(s));
+    Serial.print(',');
+    Serial.print(statePosition(s));
+    Serial.print(',');
+    Serial.print(stateMode(s));
+    Serial.print(',');
+    Serial.println((s & STATE_TOUCH_bm) ? 1 : 0);
+  }
+  if (currentSampleCount > 0) {
+    Serial.println("#current_cols=t_us,mA");
+    for (uint16_t i = 0; i < currentSampleCount; i++) {
+      Serial.print("I,");
+      Serial.print(currentSamples[i].t_us);
+      Serial.print(',');
+      Serial.println(currentSamples[i].mA, 2);
+    }
+  }
+  Serial.println("#END");
+}
+
+// Raw open-loop drive command (DEBUG_DRIVE firmware builds only)
+bool debugDrive(uint8_t flags, uint8_t duty) {
+  WireFaderBuddy.beginTransmission(FADER_BUDDY_I2C_ADDR);
+  WireFaderBuddy.write(REG_DEBUG_DRIVE);
+  WireFaderBuddy.write(flags);
+  WireFaderBuddy.write(duty);
+  return WireFaderBuddy.endTransmission() == 0;
+}
+
+// Capture while holding an open-loop drive, refreshing it often enough to keep
+// the firmware's command watchdog satisfied.
+void captureOpenLoop(uint8_t flags, uint8_t duty, uint32_t durationMs,
+                     uint32_t currentPeriodMs) {
+  sampleCount = 0;
+  currentSampleCount = 0;
+  uint32_t startUs = micros();
+  uint32_t endUs = startUs + durationMs * 1000UL;
+  uint32_t nextCurrentUs = startUs;
+  uint32_t nextRefreshUs = startUs;
+
+  while ((int32_t)(micros() - endUs) < 0 && sampleCount < MAX_SAMPLES) {
+    if ((int32_t)(micros() - nextRefreshUs) >= 0) {
+      debugDrive(flags, duty);
+      nextRefreshUs += 150000UL;  // watchdog is 400 ms
+    }
+    uint32_t s;
+    uint32_t t = micros();
+    if (faderBuddy.readState(s)) {
+      samples[sampleCount].t_us = t - startUs;
+      samples[sampleCount].state = s;
+      sampleCount++;
+    }
+    if (currentPeriodMs > 0 && inaPresent &&
+        (int32_t)(micros() - nextCurrentUs) >= 0 &&
+        currentSampleCount < MAX_CURRENT_SAMPLES) {
+      uint32_t tc = micros();
+      currentSamples[currentSampleCount].t_us = tc - startUs;
+      currentSamples[currentSampleCount].mA =
+          ina3221.getCurrentAmps(INA_CH_MOTOR) * 1000.0f;
+      currentSampleCount++;
+      nextCurrentUs += currentPeriodMs * 1000UL;
+    }
+  }
+  debugDrive(DEBUG_DRIVE_FLAGS_EXIT, 0);
+}
+
+// Drive open-loop for driveMs, then switch to stopFlags (coast or brake) for
+// the remainder, logging throughout. Used to measure stopping distance.
+void captureStopDistance(uint8_t flags, uint8_t duty, uint32_t driveMs,
+                         uint8_t stopFlags, uint32_t totalMs) {
+  sampleCount = 0;
+  currentSampleCount = 0;
+  uint32_t startUs = micros();
+  uint32_t endUs = startUs + totalMs * 1000UL;
+  uint32_t switchUs = startUs + driveMs * 1000UL;
+  uint32_t nextRefreshUs = startUs;
+  bool stopped = false;
+
+  while ((int32_t)(micros() - endUs) < 0 && sampleCount < MAX_SAMPLES) {
+    if (!stopped && (int32_t)(micros() - switchUs) >= 0) {
+      debugDrive(stopFlags, 0);
+      stopped = true;
+      nextRefreshUs = micros();
+      stopSampleIndex = sampleCount;
+    }
+    if ((int32_t)(micros() - nextRefreshUs) >= 0) {
+      debugDrive(stopped ? stopFlags : flags, stopped ? 0 : duty);
+      nextRefreshUs += 150000UL;
+    }
+    uint32_t s;
+    uint32_t t = micros();
+    if (faderBuddy.readState(s)) {
+      samples[sampleCount].t_us = t - startUs;
+      samples[sampleCount].state = s;
+      sampleCount++;
+    }
+  }
+  debugDrive(DEBUG_DRIVE_FLAGS_EXIT, 0);
+}
+
+// Wait until the fader reports INPUT_IDLE (or timeout), without logging.
+bool waitIdle(uint32_t timeoutMs) {
+  uint32_t start = millis();
+  while (millis() - start < timeoutMs) {
+    uint32_t s;
+    if (faderBuddy.readState(s) && stateMode(s) == MODE_INPUT_IDLE) {
+      return true;
+    }
+    delay(5);
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Command handling
+// ---------------------------------------------------------------------------
+
+char cmdBuf[128];
+uint8_t cmdLen = 0;
+
+void printState() {
+  uint32_t s;
+  if (!faderBuddy.readState(s)) {
+    Serial.println("ERR read state");
+    return;
+  }
+  Serial.print("OK state=0x");
+  Serial.print(s, HEX);
+  Serial.print(" mode=");
+  Serial.print(stateMode(s));
+  Serial.print(" pos=");
+  Serial.print(statePosition(s));
+  Serial.print(" raw=");
+  Serial.print(stateRawAdc(s));
+  Serial.print(" touch=");
+  Serial.println((s & STATE_TOUCH_bm) ? 1 : 0);
+}
+
+void handleCommand(char* line) {
+  char* cmd = strtok(line, " ");
+  if (cmd == nullptr) return;
+
+  if (strcmp(cmd, "ping") == 0) {
+    Serial.println("OK pong");
+
+  } else if (strcmp(cmd, "ver") == 0) {
+    uint8_t v;
+    if (faderBuddy.readProtocolVersion(v)) {
+      Serial.print("OK version=");
+      Serial.println(v);
+    } else {
+      Serial.println("ERR read version");
+    }
+
+  } else if (strcmp(cmd, "state") == 0) {
+    printState();
+
+  } else if (strcmp(cmd, "target") == 0) {
+    char* a = strtok(nullptr, " ");
+    if (a == nullptr) { Serial.println("ERR usage: target <0-255>"); return; }
+    uint8_t t = atoi(a);
+    Serial.println(faderBuddy.writeTargetPosition(t) ? "OK" : "ERR write");
+
+  } else if (strcmp(cmd, "step") == 0) {
+    // step <from> <to> <log_ms> [settle_ms]
+    char* a = strtok(nullptr, " ");
+    char* b = strtok(nullptr, " ");
+    char* c = strtok(nullptr, " ");
+    char* d = strtok(nullptr, " ");
+    if (a == nullptr || b == nullptr || c == nullptr) {
+      Serial.println("ERR usage: step <from> <to> <log_ms> [settle_ms]");
+      return;
+    }
+    uint8_t from = atoi(a);
+    uint8_t to = atoi(b);
+    uint32_t logMs = atol(c);
+    uint32_t settleMs = (d != nullptr) ? atol(d) : 700;
+
+    if (!faderBuddy.writeTargetPosition(from)) { Serial.println("ERR write from"); return; }
+    waitIdle(4000);
+    delay(settleMs);
+    if (!faderBuddy.writeTargetPosition(to)) { Serial.println("ERR write to"); return; }
+    capture(logMs, 5);
+    dumpTrace();
+    Serial.println("OK");
+
+  } else if (strcmp(cmd, "drive") == 0) {
+    // drive <flags> <duty>   (flags 255 = exit open-loop mode)
+    char* a = strtok(nullptr, " ");
+    char* b = strtok(nullptr, " ");
+    if (a == nullptr || b == nullptr) { Serial.println("ERR usage: drive <flags> <duty>"); return; }
+    Serial.println(debugDrive((uint8_t)strtoul(a, nullptr, 0),
+                              (uint8_t)strtoul(b, nullptr, 0)) ? "OK" : "ERR write");
+
+  } else if (strcmp(cmd, "openloop") == 0) {
+    // openloop <start_pos> <flags> <duty> <log_ms>
+    char* a = strtok(nullptr, " ");
+    char* b = strtok(nullptr, " ");
+    char* c = strtok(nullptr, " ");
+    char* d = strtok(nullptr, " ");
+    if (a == nullptr || b == nullptr || c == nullptr || d == nullptr) {
+      Serial.println("ERR usage: openloop <start_pos> <flags> <duty> <log_ms>");
+      return;
+    }
+    debugDrive(DEBUG_DRIVE_FLAGS_EXIT, 0);
+    delay(5);
+    if (!faderBuddy.writeTargetPosition((uint8_t)atoi(a))) { Serial.println("ERR write start"); return; }
+    waitIdle(4000);
+    delay(400);
+    captureOpenLoop((uint8_t)strtoul(b, nullptr, 0), (uint8_t)strtoul(c, nullptr, 0),
+                    atol(d), 5);
+    dumpTrace();
+    Serial.println("OK");
+
+  } else if (strcmp(cmd, "stopdist") == 0) {
+    // stopdist <start_pos> <flags> <duty> <drive_ms> <stop_flags> <total_ms>
+    char* a = strtok(nullptr, " ");
+    char* b = strtok(nullptr, " ");
+    char* c = strtok(nullptr, " ");
+    char* d = strtok(nullptr, " ");
+    char* e = strtok(nullptr, " ");
+    char* f = strtok(nullptr, " ");
+    if (!a || !b || !c || !d || !e || !f) {
+      Serial.println("ERR usage: stopdist <start> <flags> <duty> <drive_ms> <stop_flags> <total_ms>");
+      return;
+    }
+    debugDrive(DEBUG_DRIVE_FLAGS_EXIT, 0);
+    delay(5);
+    if (!faderBuddy.writeTargetPosition((uint8_t)atoi(a))) { Serial.println("ERR write start"); return; }
+    waitIdle(4000);
+    delay(400);
+    stopSampleIndex = 0;
+    captureStopDistance((uint8_t)strtoul(b, nullptr, 0), (uint8_t)strtoul(c, nullptr, 0),
+                        atol(d), (uint8_t)strtoul(e, nullptr, 0), atol(f));
+    dumpTrace();
+    Serial.println("OK");
+
+  } else if (strcmp(cmd, "log") == 0) {
+    char* a = strtok(nullptr, " ");
+    uint32_t logMs = (a != nullptr) ? atol(a) : 500;
+    capture(logMs, 5);
+    dumpTrace();
+    Serial.println("OK");
+
+  } else if (strcmp(cmd, "cal") == 0) {
+    if (!faderBuddy.selfCalibrate()) { Serial.println("ERR write"); return; }
+    delay(4000);
+    printState();
+
+  } else if (strcmp(cmd, "clearerr") == 0) {
+    Serial.println(faderBuddy.clearError() ? "OK" : "ERR write");
+
+  } else if (strcmp(cmd, "touchcal") == 0) {
+    Serial.println(faderBuddy.calibrateTouch() ? "OK" : "ERR write");
+
+  } else if (strcmp(cmd, "layer") == 0) {
+    char* a = strtok(nullptr, " ");
+    if (a == nullptr) { Serial.println("ERR usage: layer <0-7>"); return; }
+    WireFaderBuddy.beginTransmission(FADER_BUDDY_I2C_ADDR);
+    WireFaderBuddy.write(REG_ACTIVE_LAYER);
+    WireFaderBuddy.write((uint8_t)atoi(a));
+    Serial.println(WireFaderBuddy.endTransmission() == 0 ? "OK" : "ERR write");
+
+  } else if (strcmp(cmd, "haptic") == 0) {
+    // haptic <layer> <config16>
+    char* a = strtok(nullptr, " ");
+    char* b = strtok(nullptr, " ");
+    if (a == nullptr || b == nullptr) { Serial.println("ERR usage: haptic <layer> <cfg>"); return; }
+    uint16_t cfg = (uint16_t)strtoul(b, nullptr, 0);
+    WireFaderBuddy.beginTransmission(FADER_BUDDY_I2C_ADDR);
+    WireFaderBuddy.write(REG_LAYER_HAPTIC_CONFIG);
+    WireFaderBuddy.write((uint8_t)atoi(a));
+    WireFaderBuddy.write((uint8_t)(cfg >> 8));
+    WireFaderBuddy.write((uint8_t)(cfg & 0xFF));
+    Serial.println(WireFaderBuddy.endTransmission() == 0 ? "OK" : "ERR write");
+
+  } else if (strcmp(cmd, "servo") == 0) {
+    char* a = strtok(nullptr, " ");
+    if (a == nullptr) { Serial.println("ERR usage: servo <touch|clear|angle>"); return; }
+    if (strcmp(a, "touch") == 0) servo.write(SERVO_TOUCH_POS);
+    else if (strcmp(a, "clear") == 0) servo.write(SERVO_CLEAR_POS);
+    else servo.write(atoi(a));
+    Serial.println("OK");
+
+  } else if (strcmp(cmd, "power") == 0) {
+    if (!inaPresent) { Serial.println("ERR no ina3221"); return; }
+    Serial.print("OK logic_v=");
+    Serial.print(ina3221.getBusVoltage(INA_CH_LOGIC), 3);
+    Serial.print(" logic_ma=");
+    Serial.print(ina3221.getCurrentAmps(INA_CH_LOGIC) * 1000.0f, 2);
+    Serial.print(" motor_v=");
+    Serial.print(ina3221.getBusVoltage(INA_CH_MOTOR), 3);
+    Serial.print(" motor_ma=");
+    Serial.println(ina3221.getCurrentAmps(INA_CH_MOTOR) * 1000.0f, 2);
+
+  } else if (strcmp(cmd, "touch") == 0) {
+    uint16_t raw = 0, ref = 0, recal = 0;
+    int16_t delta = 0;
+    faderBuddy.readTouchRaw(raw);
+    faderBuddy.readTouchDelta(delta);
+    faderBuddy.readTouchReference(ref);
+    faderBuddy.readTouchRecalCount(recal);
+    uint32_t st = 0;
+    faderBuddy.readState(st);
+    Serial.print("OK touch_bit="); Serial.print((st & STATE_TOUCH_bm) ? 1 : 0);
+    Serial.print(" raw="); Serial.print(raw);
+    Serial.print(" delta="); Serial.print(delta);
+    Serial.print(" ref="); Serial.print(ref);
+    Serial.print(" recal="); Serial.println(recal);
+
+  } else if (strcmp(cmd, "gain") == 0) {
+    // gain <index> <value>   (KP/KD/deadband are x1000)
+    char* a = strtok(nullptr, " ");
+    char* b = strtok(nullptr, " ");
+    if (a == nullptr || b == nullptr) { Serial.println("ERR usage: gain <index> <value>"); return; }
+    int16_t v = (int16_t)atoi(b);
+    WireFaderBuddy.beginTransmission(FADER_BUDDY_I2C_ADDR);
+    WireFaderBuddy.write(REG_DEBUG_GAINS);
+    WireFaderBuddy.write((uint8_t)atoi(a));
+    WireFaderBuddy.write((uint8_t)((uint16_t)v >> 8));
+    WireFaderBuddy.write((uint8_t)((uint16_t)v & 0xFF));
+    Serial.println(WireFaderBuddy.endTransmission() == 0 ? "OK" : "ERR write");
+
+  } else if (strcmp(cmd, "dbg") == 0) {
+    uint8_t d[16];
+    WireFaderBuddy.beginTransmission(FADER_BUDDY_I2C_ADDR);
+    WireFaderBuddy.write(REG_DEBUG_STATUS);
+    if (WireFaderBuddy.endTransmission(false) != 0) { Serial.println("ERR write"); return; }
+    if (WireFaderBuddy.requestFrom((uint8_t)FADER_BUDDY_I2C_ADDR, (size_t)16) != 16) {
+      Serial.println("ERR read"); return;
+    }
+    for (uint8_t i = 0; i < 16; i++) d[i] = WireFaderBuddy.read();
+    int16_t v[8];
+    for (uint8_t i = 0; i < 8; i++) v[i] = (int16_t)(((uint16_t)d[i*2] << 8) | d[i*2+1]);
+    Serial.print("OK calib_min="); Serial.print((uint16_t)v[0]);
+    Serial.print(" calib_max="); Serial.print((uint16_t)v[1]);
+    Serial.print(" target_adc="); Serial.print(v[2]);
+    Serial.print(" drive="); Serial.print(v[3]);
+    Serial.print(" vel="); Serial.print(v[4]);
+    Serial.print(" err="); Serial.print(v[5] / 8.0f, 2);
+    Serial.print(" loop_hz="); Serial.print((uint16_t)v[6]);
+    Serial.print(" tick_hz="); Serial.println((uint16_t)v[7]);
+
+  } else if (strcmp(cmd, "rate") == 0) {
+    // Measure achievable I2C poll rate
+    uint32_t start = millis();
+    uint16_t n = 0;
+    uint32_t s;
+    while (millis() - start < 200) {
+      if (faderBuddy.readState(s)) n++;
+    }
+    Serial.print("OK poll_hz=");
+    Serial.println(n * 5);
+
+  } else {
+    Serial.print("ERR unknown command: ");
+    Serial.println(cmd);
+  }
+}
+
+void setup() {
+  pinMode(PIN_LED_RED, OUTPUT);
+  pinMode(PIN_LED_GREEN, OUTPUT);
+  digitalWrite(PIN_LED_RED, LOW);
+  digitalWrite(PIN_LED_GREEN, HIGH);
+
+  Serial.begin(921600);
+
+  Wire.begin(PIN_INA_SDA, PIN_INA_SCL);
+  WireFaderBuddy.begin(PIN_FADER_BUDDY_SDA, PIN_FADER_BUDDY_SCL, 400000);
+  faderBuddy.begin(&WireFaderBuddy);
+
+  servo.attach(PIN_SERVO);
+  servo.write(SERVO_CLEAR_POS);
+
+  inaPresent = ina3221.begin(0x40, &Wire);
+  if (inaPresent) {
+    ina3221.setAveragingMode(INA3221_AVG_1_SAMPLE);
+    for (uint8_t i = 0; i < 3; i++) {
+      ina3221.setShuntResistance(i, 0.1);
+    }
+  }
+
+  delay(200);
+  Serial.println("#LAB READY");
+}
+
+void loop() {
+  while (Serial.available()) {
+    char c = Serial.read();
+    if (c == '\n' || c == '\r') {
+      if (cmdLen > 0) {
+        cmdBuf[cmdLen] = '\0';
+        handleCommand(cmdBuf);
+        cmdLen = 0;
+      }
+    } else if (cmdLen < sizeof(cmdBuf) - 1) {
+      cmdBuf[cmdLen++] = c;
+    }
+  }
+}

--- a/production_tools/programAndTest/src/lab_main.cpp
+++ b/production_tools/programAndTest/src/lab_main.cpp
@@ -295,6 +295,34 @@ void handleCommand(char* line) {
     uint8_t t = atoi(a);
     Serial.println(faderBuddy.writeTargetPosition(t) ? "OK" : "ERR write");
 
+  } else if (strcmp(cmd, "sstep") == 0) {
+    // sstep <from> <to> <speed> <log_ms>  - step with the optional speed limit
+    char* a = strtok(nullptr, " ");
+    char* b = strtok(nullptr, " ");
+    char* c = strtok(nullptr, " ");
+    char* d = strtok(nullptr, " ");
+    if (!a || !b || !c || !d) { Serial.println("ERR usage: sstep <from> <to> <speed> <log_ms>"); return; }
+    uint8_t speed = (uint8_t)atoi(c);
+    // move to the start position at full speed
+    WireFaderBuddy.beginTransmission(FADER_BUDDY_I2C_ADDR);
+    WireFaderBuddy.write(REG_LAYER_TARGET);
+    WireFaderBuddy.write((uint8_t)0);
+    WireFaderBuddy.write((uint8_t)atoi(a));
+    WireFaderBuddy.write((uint8_t)LAYER_MOVE_TIME_UNLIMITED);
+    if (WireFaderBuddy.endTransmission() != 0) { Serial.println("ERR write from"); return; }
+    waitIdle(6000);
+    delay(500);
+    // then the measured move, speed limited
+    WireFaderBuddy.beginTransmission(FADER_BUDDY_I2C_ADDR);
+    WireFaderBuddy.write(REG_LAYER_TARGET);
+    WireFaderBuddy.write((uint8_t)0);
+    WireFaderBuddy.write((uint8_t)atoi(b));
+    WireFaderBuddy.write(speed);
+    if (WireFaderBuddy.endTransmission() != 0) { Serial.println("ERR write to"); return; }
+    capture(atol(d), 5);
+    dumpTrace();
+    Serial.println("OK");
+
   } else if (strcmp(cmd, "step") == 0) {
     // step <from> <to> <log_ms> [settle_ms]
     char* a = strtok(nullptr, " ");
@@ -456,16 +484,16 @@ void handleCommand(char* line) {
     Serial.println(WireFaderBuddy.endTransmission() == 0 ? "OK" : "ERR write");
 
   } else if (strcmp(cmd, "dbg") == 0) {
-    uint8_t d[16];
+    uint8_t d[18];
     WireFaderBuddy.beginTransmission(FADER_BUDDY_I2C_ADDR);
     WireFaderBuddy.write(REG_DEBUG_STATUS);
     if (WireFaderBuddy.endTransmission(false) != 0) { Serial.println("ERR write"); return; }
-    if (WireFaderBuddy.requestFrom((uint8_t)FADER_BUDDY_I2C_ADDR, (size_t)16) != 16) {
+    if (WireFaderBuddy.requestFrom((uint8_t)FADER_BUDDY_I2C_ADDR, (size_t)18) != 18) {
       Serial.println("ERR read"); return;
     }
-    for (uint8_t i = 0; i < 16; i++) d[i] = WireFaderBuddy.read();
-    int16_t v[8];
-    for (uint8_t i = 0; i < 8; i++) v[i] = (int16_t)(((uint16_t)d[i*2] << 8) | d[i*2+1]);
+    for (uint8_t i = 0; i < 18; i++) d[i] = WireFaderBuddy.read();
+    int16_t v[9];
+    for (uint8_t i = 0; i < 9; i++) v[i] = (int16_t)(((uint16_t)d[i*2] << 8) | d[i*2+1]);
     Serial.print("OK calib_min="); Serial.print((uint16_t)v[0]);
     Serial.print(" calib_max="); Serial.print((uint16_t)v[1]);
     Serial.print(" target_adc="); Serial.print(v[2]);
@@ -473,7 +501,8 @@ void handleCommand(char* line) {
     Serial.print(" vel="); Serial.print(v[4]);
     Serial.print(" err="); Serial.print(v[5] / 8.0f, 2);
     Serial.print(" loop_hz="); Serial.print((uint16_t)v[6]);
-    Serial.print(" tick_hz="); Serial.println((uint16_t)v[7]);
+    Serial.print(" tick_hz="); Serial.print((uint16_t)v[7]);
+    Serial.print(" vmax="); Serial.println((uint16_t)v[8]);
 
   } else if (strcmp(cmd, "rate") == 0) {
     // Measure achievable I2C poll rate

--- a/production_tools/programAndTest/src/lab_main.cpp
+++ b/production_tools/programAndTest/src/lab_main.cpp
@@ -471,7 +471,7 @@ void handleCommand(char* line) {
     Serial.print(" recal="); Serial.println(recal);
 
   } else if (strcmp(cmd, "gain") == 0) {
-    // gain <index> <value>   (KP/KD/deadband are x1000)
+    // gain <index> <value>   (vref slope, KV and deadband are x1000)
     char* a = strtok(nullptr, " ");
     char* b = strtok(nullptr, " ");
     if (a == nullptr || b == nullptr) { Serial.println("ERR usage: gain <index> <value>"); return; }

--- a/production_tools/programAndTest/src/lab_main.cpp
+++ b/production_tools/programAndTest/src/lab_main.cpp
@@ -296,7 +296,7 @@ void handleCommand(char* line) {
     Serial.println(faderBuddy.writeTargetPosition(t) ? "OK" : "ERR write");
 
   } else if (strcmp(cmd, "sstep") == 0) {
-    // sstep <from> <to> <speed> <log_ms>  - step with the optional speed limit
+    // sstep <from> <to> <speed> <log_ms>  - step at a unitless speed (0-255, 255 = full)
     char* a = strtok(nullptr, " ");
     char* b = strtok(nullptr, " ");
     char* c = strtok(nullptr, " ");
@@ -308,7 +308,7 @@ void handleCommand(char* line) {
     WireFaderBuddy.write(REG_LAYER_TARGET);
     WireFaderBuddy.write((uint8_t)0);
     WireFaderBuddy.write((uint8_t)atoi(a));
-    WireFaderBuddy.write((uint8_t)LAYER_MOVE_TIME_UNLIMITED);
+    WireFaderBuddy.write((uint8_t)LAYER_SPEED_FULL);
     if (WireFaderBuddy.endTransmission() != 0) { Serial.println("ERR write from"); return; }
     waitIdle(6000);
     delay(500);

--- a/production_tools/programAndTest/src/main.cpp
+++ b/production_tools/programAndTest/src/main.cpp
@@ -825,7 +825,7 @@ void readFaderBuddyState() {
 }
 
 bool testSelfCalibration() {
-  const uint32_t TOTAL_TIMEOUT_MS = 8000;
+  const uint32_t TOTAL_TIMEOUT_MS = 15000;
   const uint32_t MODE_ENTRY_TIMEOUT_MS = 1000;
   const uint16_t MIN_ADC_THRESHOLD = 100;
   const uint16_t MAX_ADC_THRESHOLD = 1900;

--- a/software/mcp2221-webhid/src/faderBuddy.js
+++ b/software/mcp2221-webhid/src/faderBuddy.js
@@ -48,6 +48,9 @@ export class FaderBuddy {
         this.REG_ACTIVE_LAYER = 0x0D;
         this.REG_LAYER_TARGET = 0x0E;         // Layer-addressed
         this.REG_LAYER_HAPTIC_CONFIG = 0x0F;  // Layer-addressed
+        // 0x10 reserved for REG_ENTER_BOOTLOADER
+        this.REG_FW_VERSION = 0x11;
+        this.REG_MOTOR_CAL = 0x12;
 
         // Mode states
         this.MODE_REMOTE_MOVEMENT = 0;
@@ -338,6 +341,41 @@ export class FaderBuddy {
      */
     async selfCalibrate() {
         await this.writeRegister(this.REG_SELF_CAL);
+    }
+
+    /**
+     * Read what self-calibration measured about this unit's motor, and the
+     * gains derived from it. Diagnostic: these are the numbers to look at when
+     * a fader hunts near its target or settles slowly.
+     *
+     * `valid` false means the unit has never been characterised (or the
+     * measurement was rejected), and the compiled-in default gains are in use -
+     * run selfCalibrate() to measure it.
+     *
+     * breakaway and k feed the feedforward (breakaway + v_ref/k) and the
+     * velocity loop gain (scaled by 1/k); jump sets velMin and the deadband.
+     *
+     * @returns {object} - {valid, breakaway: {rising, falling},
+     *                      k: {rising, falling}, jump: {rising, falling},
+     *                      velMin, deadband}
+     */
+    async readMotorCalibration() {
+        const d = await this.readRegister(this.REG_MOTOR_CAL, 12);
+        return {
+            valid: d[0] !== 0,
+            // Duty at which the carriage first moves at all
+            breakaway: { rising: d[1], falling: d[2] },
+            // ADC counts/sec of cruise gained per duty count above breakaway
+            k: { rising: d[3], falling: d[4] },
+            // Speed motion starts at once breakaway is crossed (Stribeck jump)
+            jump: {
+                rising: (d[5] << 8) | d[6],
+                falling: (d[7] << 8) | d[8],
+            },
+            // What the control law runs with, measured or default
+            velMin: (d[9] << 8) | d[10],
+            deadband: d[11],
+        };
     }
 
     /**


### PR DESCRIPTION
Gave Claude a program&test jig and asked it to redo the motor control to reduce overshoot and eliminate audible noise (since I previously lowered the PWM freq as a cheap way to get better torque). Claude ran a bunch of tests to characterize the fader's performance and then wrote a new control loop that seems to work pretty well. Also made a bunch of quality of life tweaks.

Big changes:
- quiet movement
- less overshoot, and built-in motor self calibration
- adjustable movement speed
- firmware version reporting
- esphome improvements:
  - automatically register/report serial number and firmware version text fields per fader
  - automatically register Self calibration button

Cleanup:
- extracted self calibration to a separate file
- CI check that i2c protocol files stay in sync

Manually tested end-to-end with esphome component.